### PR TITLE
Use MY_GITHUB_TOKEN instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened]
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
 
 jobs:
   assign_to_project:


### PR DESCRIPTION
Since the project that we're adding issues to isn't in the eclipse-pass/main repo, the default GITHUB_TOKEN doesn't have authorization to add issues to it. Instead, I've generated a token for my own user and had that token added to the repo as a secret named MY_GITHUB_TOKEN. The srggrs/assign-one-project-github-action workflow automatically looks for the MY_GITHUB_TOKEN when the specified project is outside the repo.

I also investigated a guard to ensure that this was only run if the issue hadn't already been assigned to a project. However, the information received when a new issue is created doesn't include information about projects. Adding this might be possible through API queries but I believe adding to a project that an issue already belongs to won't have any effect and when an issue is created it can't be assigned to a column (e.g., To Do, In Progress) so the workflow shouldn't be changing a value  set by the creator.