### PR TITLE
configure snapshot release to use legacy nexus repository oss.sonatyp…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>oss</id>
+      <id>ossrh</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
@@ -219,7 +219,7 @@
           <version>${nexus-staging-maven-plugin.version}</version>
           <extensions>true</extensions>
           <configuration>
-            <serverId>oss</serverId>
+            <serverId>ossrh</serverId>
             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
            <!-- Set this to true and the release will automatically proceed and sync to Central Repository
            will follow  -->

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <id>oss</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 
@@ -219,8 +219,8 @@
           <version>${nexus-staging-maven-plugin.version}</version>
           <extensions>true</extensions>
           <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+            <serverId>oss</serverId>
+            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
            <!-- Set this to true and the release will automatically proceed and sync to Central Repository
            will follow  -->
             <autoReleaseAfterClose>true</autoReleaseAfterClose>


### PR DESCRIPTION
…e.org

Per Joel Orlina at sonatype,  org.eclipse group ids are deployed on the legacy host oss.sonatype.org, not the newer s01 version. setting my credentials locally in my .m2/settings.xml file resulted in a successful deploy of eclipse-pass/main. this should unblock the rest of #234, once the group ids of other repos are updated.

anyone needing to perform releases will have to get deploy privileges on oss.sonatype.org if they do not have them already.
I think i can request these permissions from Joel by simply commenting on https://issues.sonatype.org/browse/OSSRH-81761