### PR TITLE
Document hooking up EF Infra and DigitalOcean as a GitHub self-hosted runner

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,3 +15,4 @@ any relevant websites, external references, and other cloud storages (e.g. Googl
 * [Troubleshooting dev issues](/docs/dev/troubleshooting.md)
 * [Deployment Pipeline](/docs/infra/pipeline.md)
 * [PASS via EC2](/docs/infra/ec2.md)
+* [PASS via Digital Ocean](/docs/infra/digitalocean.md)

--- a/docs/infra/README.md
+++ b/docs/infra/README.md
@@ -104,3 +104,4 @@ hosted by the Eclipse Foundation./
 * [Our attempt to use Komposer to migrate Docker Compose to k8s manifest](/docs/infra/docker-composer-to-k8s-manifest.md)
 * [Working with GitHub secrets](/docs/infra/github-secrets.md)
 * [Self-Hosted GitHub Runners](/docs/infra/self_hosted_github_runners.md)
+* [Eclipse Foundation ops](/docs/infra/eclipseops.md)

--- a/docs/infra/digitalocean.md
+++ b/docs/infra/digitalocean.md
@@ -1,7 +1,6 @@
 # PASS Digital Ocean Deployment
 
 This will document how to run PASS in [Digital Ocean](https://www.digitalocean.com)
-as well as how to use [Digital Ocean](https://www.digitalocean.com) as a droplet
 as [Self-Hosted GitHub Runners](/docs/infra/self_hosted_github_runners.md).
 
 ## Create Server

--- a/docs/infra/digitalocean.md
+++ b/docs/infra/digitalocean.md
@@ -1,0 +1,90 @@
+# PASS Digital Ocean Deployment
+
+This will document how to run PASS in [Digital Ocean](https://www.digitalocean.com)
+as well as how to use [Digital Ocean](https://www.digitalocean.com) as a droplet
+as [Self-Hosted GitHub Runners](/docs/infra/self_hosted_github_runners.md).
+
+## Create Server
+
+You will first need a
+[linux server as your base OS](https://docs.digitalocean.com/products/droplets/how-to/create/)
+with [sudo privileges](https://en.wikipedia.org/wiki/Sudo).
+
+Going forward, the following scripts will be RUN ON THE SERVER, for example
+after you SSH into the box.
+
+```bash
+ssh <IP>
+```
+
+## Install PASS Dependencies
+
+On the server, you will need [docker / docker-compose](https://docs.docker.com/compose/) and [pass-docker](https://github.com/eclipse-pass/pass-docker)
+
+The following script will install those dependencies (these should be run as [sudo](https://en.wikipedia.org/wiki/Sudo))
+
+```bash
+apt-get -y update
+apt-get install -y gnupg2 pass docker-compose
+mkdir -p /src
+cd /src
+git clone git@github.com:eclipse-pass/pass-docker.git
+cd pass-docker
+git checkout minimal-assets
+
+```
+
+Or, you can run this directly on your server
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/eclipse-pass/main/main/tools/github_runner/deps.sh)"
+```
+
+If the installation worked, then you can pull and run the application
+
+```bash
+cd /src/pass-docker && \
+  docker-compose pull && \
+  docker-compose up
+```
+
+## Install GitHub Runner Scripts
+
+If you also wanted to use this server as a
+[self-Hosted GitHub Runners software](/docs/infra/self_hosted_github_runners.md)
+then run
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/eclipse-pass/main/main/tools/github_runner/install.sh)"
+```
+
+## Connect Server to GitHub Runner
+
+You can then connect the server to GitHub using the following variables
+
+```bash
+
+````
+
+To execute the following script.
+
+```bash
+(cd /opt/githubrunner && \
+  sudo -u githubrunner ./config.sh \
+    --unattended \
+    --url https://github.com/${PASSORG}/pass-docker \
+    --token $GITHUB_RUNNER_TOKEN \
+    --name $NAME \
+    --runnergroup default \
+    --labels $NAME \
+    --work pass-docker \
+    --replace && \
+  ./svc.sh install githubrunner && \
+  ./svc.sh start)
+```
+
+These scripts to [add.sh](/tools/github_runner/add.sh)
+and [remove.sh](/tools/github_runner/remove.sh)
+your server from GitHub Runner
+are available in [/tools/github_runner](/tools/github_runner).
+

--- a/docs/infra/digitalocean.md
+++ b/docs/infra/digitalocean.md
@@ -63,7 +63,8 @@ then run
 You can then connect the server to GitHub using the following variables
 
 ```bash
-
+PASSORG=eclipse-pass
+GITHUB_RUNNER_TOKEN=ghp_abc123def456abc123def456abc123def456
 ````
 
 To execute the following script.

--- a/docs/infra/digitalocean.md
+++ b/docs/infra/digitalocean.md
@@ -31,7 +31,6 @@ cd /src
 git clone git@github.com:eclipse-pass/pass-docker.git
 cd pass-docker
 git checkout minimal-assets
-
 ```
 
 Or, you can run this directly on your server

--- a/docs/infra/eclipseops.md
+++ b/docs/infra/eclipseops.md
@@ -19,3 +19,19 @@ GITHUB_RUNNER_TOKEN=XXX
 ```
 
 Learn more from the [installer script itself](/tools/eclipse_ops/bootstrap).
+
+## Run PASS
+
+To manually run the application, execute
+
+```bash
+cd /src/pass-docker && \
+  sudo docker-compose pull && \
+  sudo docker-compose up
+```
+
+If you want to run in the background then use `-d`.
+
+```bash
+sudo docker-compose up -d
+```

--- a/docs/infra/eclipseops.md
+++ b/docs/infra/eclipseops.md
@@ -1,0 +1,21 @@
+# Eclipse Foundation Operations
+
+A bootstrapped server [installer](/tools/eclipse_ops/bootstrap)
+to run a stand-alone PASS application via the [pass-docker](https://github.com/eclipse-pass/pass-docker)
+project
+
+Which will do the following
+
+* Install docker
+* Install [github self-hosted runners](/docs/infra/self_hosted_github_runners.md)
+* Intall [pass-docker](https://github.com/eclipse-pass/pass-docker)
+* Configure [pass docker for a GH runner](/docs/infra/self_hosted_github_runners.md)
+
+To configure the self-hosted runner you will need the GITHUB token,
+replacing the `XXX` with the actual token value.
+
+```
+GITHUB_RUNNER_TOKEN=XXX
+```
+
+Learn more from the [installer script itself](/tools/eclipse_ops/bootstrap).

--- a/docs/infra/pipeline.md
+++ b/docs/infra/pipeline.md
@@ -262,6 +262,7 @@ The following repositories have been forked from others
 
 * [Deploying pass-docker via EC2](/docs/infra/ec2.md)
 * [Deploying pass-docker via Digital Ocean](/docs/infra/digitalocean.md)
+* [Deploying pass-docker via Eclipse Foundation (EF)](/docs/infra/eclipseops.md)
 * [Our attempt to use Komposer to migrate Docker Compose to k8s manifest](/docs/infra/docker-composer-to-k8s-manifest.md)
 * [Travis configs for pass-ui](https://travis-ci.org/github/OA-PASS/pass-ember/jobs/770188235/config)
 * [Coveralls for pass-ui (pass-ember URL no longer valid)](https://coveralls.io/)

--- a/docs/infra/pipeline.md
+++ b/docs/infra/pipeline.md
@@ -261,6 +261,7 @@ The following repositories have been forked from others
 ## References
 
 * [Deploying pass-docker via EC2](/docs/infra/ec2.md)
+* [Deploying pass-docker via Digital Ocean](/docs/infra/digitalocean.md)
 * [Our attempt to use Komposer to migrate Docker Compose to k8s manifest](/docs/infra/docker-composer-to-k8s-manifest.md)
 * [Travis configs for pass-ui](https://travis-ci.org/github/OA-PASS/pass-ember/jobs/770188235/config)
 * [Coveralls for pass-ui (pass-ember URL no longer valid)](https://coveralls.io/)

--- a/docs/infra/self_hosted_github_runners.md
+++ b/docs/infra/self_hosted_github_runners.md
@@ -39,6 +39,32 @@ mkdir -p /opt/actions-runner
  tar xzf ./actions-runner-linux-x64-2.293.0.tar.gz)
 ```
 
+A helper script has been created (and tested on a Linux x64 server) to
+help you setup your self-hosted runner.  Copy and execute
+[/tools/github_runner/install.sh](/tools/github_runner/install.sh)
+on your self-hosted server.
+
+Or, you can run this directly on your server
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/eclipse-pass/main/main/tools/github_runner/install.sh)"
+```
+
+If the installation above worked, you should be able to run
+
+```bash
+cd /opt/githubrunner && sudo -u githubrunner ./config.sh --help
+```
+
+And see something similar to
+
+```bash
+Commands:
+ ./config.sh         Configures the runner
+ ./config.sh remove  Unconfigures the runner
+ ./run.sh            Runs the runner interactively. Does not require any options.
+```
+
 ### Configure Runner
 
 Then we create the runner and start the configuration experience.

--- a/docs/infra/self_hosted_github_runners.md
+++ b/docs/infra/self_hosted_github_runners.md
@@ -39,6 +39,14 @@ mkdir -p /opt/actions-runner
  tar xzf ./actions-runner-linux-x64-2.293.0.tar.gz)
 ```
 
+Note that any service that you want to run on the self-hosted runner
+must be accessible via `githubrunner` group.  For example, to
+run docker commands, you will need to modify the `docker` user as follows
+
+```bash
+usermod -aG docker githubrunner
+```
+
 A helper script has been created (and tested on a Linux x64 server) to
 help you setup your self-hosted runner.  Copy and execute
 [/tools/github_runner/install.sh](/tools/github_runner/install.sh)

--- a/tools/eclipse_ops/bootstrap
+++ b/tools/eclipse_ops/bootstrap
@@ -20,9 +20,9 @@ GITHUB_RUNNER_LABEL=passnightly
 # to get a two-hop working between
 # bastion.eclipse.org and the individual servers
 
-printf "%b" "
-#!/bin/bash
+echo '#!/bin/bash' > /tmp/installer.sh
 
+printf "%b" "
 function go() {
   touch /opt/boostrap.start && \\
     install_docker && \\
@@ -83,8 +83,8 @@ function configure_passdocker_runner() {
 
 go
 
-" > /tmp/installer.sh
+" >> /tmp/installer.sh
 
 chmod 755 /tmp/installer.sh
 
-/tmp/installer.sh
+sudo /tmp/installer.sh

--- a/tools/eclipse_ops/bootstrap
+++ b/tools/eclipse_ops/bootstrap
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Remote into the box, for example
+#
+# ssh a2forward@bastion.eclipse.org -t ssh a2forward@172.30.206.14
+#
+# Configure the following secrets/configs
+# Your RUNNER TOKEN is available from /settings/actions/runners/new
+GITHUB_RUNNER_TOKEN=XXX
+
+# Adjust these as needed
+GITHUB_ORG=eclipse-pass
+GITHUB_PROJECT_URL=https://github.com/${GITHUB_ORG}/pass-docker
+GITHUB_PROJECT_GIT=https://github.com/${GITHUB_ORG}/pass-docker.git
+GITHUB_RUNNER_LABEL=passnightly
+
+# Then copy and paste the bootstrap code
+#
+# Ideally we would SCP the file, but I was not able
+# to get a two-hop working between
+# bastion.eclipse.org and the individual servers
+
+printf "%b" "
+#!/bin/bash
+
+function go() {
+  touch /opt/boostrap.start && \\
+    install_docker && \\
+    install_githubrunner && \\
+    install_passdocker && \\
+    configure_passdocker_runner && \\
+    mv /opt/boostrap.start /opt/boostrap.end
+}
+
+function install_docker() {
+  touch /opt/docker.start && \\
+    apt-get -y update && \\
+    apt-get install -y gnupg2 pass docker-compose && \\
+    mv /opt/docker.start /opt/docker.end
+}
+
+function install_githubrunner() {
+  VERSION=2.294.0
+  CHECKSUM=a19a09f4eda5716e5d48ba86b6b78fc014880c5619b9dba4a059eaf65e131780
+
+  touch /opt/githubrunner.start && \\
+    mkdir -p /opt/githubrunner && \\
+    (useradd githubrunner || true) && \\
+    usermod -aG docker githubrunner && \\
+    (cd /opt/githubrunner && \\
+      curl -o actions-runner-linux-x64-\${VERSION}.tar.gz -L https://github.com/actions/runner/releases/download/v\${VERSION}/actions-runner-linux-x64-\${VERSION}.tar.gz && \\
+      echo \"\${CHECKSUM}  actions-runner-linux-x64-\${VERSION}.tar.gz\" | shasum -a 256 -c && \\
+      tar xzf ./actions-runner-linux-x64-\${VERSION}.tar.gz) && \\
+    chown -R githubrunner:githubrunner /opt/githubrunner && \\
+    mv /opt/githubrunner.start /opt/githubrunner.end
+}
+
+function install_passdocker() {
+  touch /opt/pass-docker.start && \\
+    mkdir -p /src && \\
+    (ssh -o \"StrictHostKeyChecking=no\" github.com || true) && \\
+    (cd /src && git clone $GITHUB_PROJECT_GIT) && \\
+    mv /opt/pass-docker.start /opt/pass-docker.end
+}
+
+function configure_passdocker_runner() {
+  touch /opt/passdocker_runner.start  && \\
+  (cd /opt/githubrunner && \\
+    sudo -u githubrunner ./config.sh remove --token $GITHUB_RUNNER_TOKEN && \\
+    sudo -u githubrunner ./config.sh \\
+      --unattended \\
+      --url $GITHUB_PROJECT_URL \\
+      --token $GITHUB_RUNNER_TOKEN \\
+      --name $GITHUB_RUNNER_LABEL \\
+      --runnergroup default \\
+      --labels $GITHUB_RUNNER_LABEL \\
+      --work pass-docker \\
+      --replace && \\
+    ./svc.sh install githubrunner && \\
+    ./svc.sh start) && \\
+  mv /opt/passdocker_runner.start /opt/passdocker_runner.end
+}
+
+go
+
+" > /tmp/installer.sh
+
+chmod 755 /tmp/installer.sh
+
+/tmp/installer.sh

--- a/tools/github_runner/add.sh
+++ b/tools/github_runner/add.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# To add your self-hosted runner
+# Replace with your GitHub Runner Token
+# (change URL to your GitHub organization if you forked the application)
+# https://github.com/eclipse-pass/main/settings/actions/runners/new?arch=x64&os=linux
+#
+# GITHUB_RUNNER_TOKEN=AABBCCDDEEAABBCCDDEEAABBCCDDE \
+#   ./add.sh \
+#   passapp-dev
+
+# The name/label of the runner
+NAME=${1-passapp}
+
+# You must provide this on the command line
+GITHUB_RUNNER_TOKEN=${GITHUB_RUNNER_TOKEN-na}
+
+# Change this if you are running a forked version
+# of the pass application
+PASSORG=${PASSORG-eclipse-pass}
+
+(cd /opt/githubrunner && \
+  sudo -u githubrunner ./config.sh \
+    --unattended \
+    --url https://github.com/${PASSORG}/pass-docker \
+    --token $GITHUB_RUNNER_TOKEN \
+    --name $NAME \
+    --runnergroup default \
+    --labels $NAME \
+    --work pass-docker \
+    --replace && \
+  ./svc.sh install githubrunner && \
+  ./svc.sh start)

--- a/tools/github_runner/deps.sh
+++ b/tools/github_runner/deps.sh
@@ -18,7 +18,7 @@ function install_docker()
     touch /opt/docker.start && \
     apt-get -y update && \
     apt-get install -y gnupg2 pass docker-compose && \
-    usermod -aG docker githubrunner && \
+    (usermod -aG docker githubrunner || true) && \
     mv /opt/docker.start /opt/docker.end && \
     echo "... done installing docker"
 }

--- a/tools/github_runner/deps.sh
+++ b/tools/github_runner/deps.sh
@@ -28,7 +28,10 @@ function install_passdocker()
   echo "installing pass-docker ..." && \
     touch /opt/pass-docker.start && \
     mkdir -p /src && \
-    (cd /src && git clone git@github.com:${PASSORG}/pass-docker.git) && \
+    (cd /src && \
+      git clone git@github.com:${PASSORG}/pass-docker.git && \
+      cd pass-docker && \
+      git checkout minimal-assets) && \
     mv /opt/pass-docker.start /opt/pass-docker.end && \
     echo "... done installing pass-docker"
 }

--- a/tools/github_runner/deps.sh
+++ b/tools/github_runner/deps.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Install PASS specific dependencies before adding the runner
+# ./deps.sh
+
+# Change this if you are running a forked version
+# of the pass application
+PASSORG=${PASSORG-eclipse-pass}
+
+function trust_github()
+{
+  (ssh -o "StrictHostKeyChecking=no" github.com || true)
+}
+
+function install_docker()
+{
+  echo "installing docker ..." && \
+    touch /opt/docker.start && \
+    apt-get -y update && \
+    apt-get install -y gnupg2 pass docker-compose && \
+    usermod -aG docker githubrunner && \
+    mv /opt/docker.start /opt/docker.end && \
+    echo "... done installing docker"
+}
+
+function install_passdocker()
+{
+  echo "installing pass-docker ..." && \
+    touch /opt/pass-docker.start && \
+    mkdir -p /src && \
+    (cd /src && git clone git@github.com:${PASSORG}/pass-docker.git) && \
+    mv /opt/pass-docker.start /opt/pass-docker.end && \
+    echo "... done installing pass-docker"
+}
+
+(echo "installing pass-app deps ..." && \
+  touch /opt/pass-app-deps.start  && \
+  trust_github && \
+  install_docker && \
+  install_passdocker && \
+  mv /opt/pass-app-deps.start /opt/pass-app-deps.end && \
+  echo "... done installing pass-app deps")

--- a/tools/github_runner/install.sh
+++ b/tools/github_runner/install.sh
@@ -13,8 +13,9 @@ function install_githubrunner()
 {
   echo "installing githubrunner ..." && \
     touch /opt/githubrunner.start && \
+    rm -rf /opt/githubrunner && \
     mkdir /opt/githubrunner && \
-    useradd githubrunner && \
+    (useradd githubrunner || true) && \
     (cd /opt/githubrunner && \
      curl -o actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz -L https://github.com/actions/runner/releases/download/v${GITHUB_RUNNER_VERSION}/actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz && \
      echo "${GITHUB_RUNNER_CHECKSUM}  actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz" | shasum -a 256 -c && \

--- a/tools/github_runner/install.sh
+++ b/tools/github_runner/install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Install GitHub Runner on your self-hosted server
+# ./install.sh
+
+# To get the latest GitHub Runner version, visit
+# (change URL to your GitHub organization if you forked the application)
+# https://github.com/eclipse-pass/main/settings/actions/runners/new?arch=x64&os=linux
+GITHUB_RUNNER_VERSION=2.293.0
+GITHUB_RUNNER_CHECKSUM="06d62d551b686239a47d73e99a557d87e0e4fa62bdddcf1d74d4e6b2521f8c10"
+
+function install_githubrunner()
+{
+  echo "installing githubrunner ..." && \
+    touch /opt/githubrunner.start && \
+    mkdir /opt/githubrunner && \
+    useradd githubrunner && \
+    (cd /opt/githubrunner && \
+     curl -o actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz -L https://github.com/actions/runner/releases/download/v${GITHUB_RUNNER_VERSION}/actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz && \
+     echo "${GITHUB_RUNNER_CHECKSUM}  actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz" | shasum -a 256 -c && \
+     tar xzf ./actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz) && \
+    chown -R githubrunner:githubrunner /opt/githubrunner && \
+    mv /opt/githubrunner.start /opt/githubrunner.end && \
+    echo "... done installing githubrunner"
+}
+
+(echo "installing GitHub Runner ..." && \
+  touch /opt/github-runner.start  && \
+  install_githubrunner && \
+  mv /opt/github-runner.start /opt/github-runner.end && \
+  echo "... done installing github-runner")

--- a/tools/github_runner/install.sh
+++ b/tools/github_runner/install.sh
@@ -16,6 +16,7 @@ function install_githubrunner()
     rm -rf /opt/githubrunner && \
     mkdir /opt/githubrunner && \
     (useradd githubrunner || true) && \
+    (usermod -aG docker githubrunner || true) && \
     (cd /opt/githubrunner && \
      curl -o actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz -L https://github.com/actions/runner/releases/download/v${GITHUB_RUNNER_VERSION}/actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz && \
      echo "${GITHUB_RUNNER_CHECKSUM}  actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz" | shasum -a 256 -c && \

--- a/tools/github_runner/install.sh
+++ b/tools/github_runner/install.sh
@@ -6,8 +6,8 @@
 # To get the latest GitHub Runner version, visit
 # (change URL to your GitHub organization if you forked the application)
 # https://github.com/eclipse-pass/main/settings/actions/runners/new?arch=x64&os=linux
-GITHUB_RUNNER_VERSION=2.293.0
-GITHUB_RUNNER_CHECKSUM="06d62d551b686239a47d73e99a557d87e0e4fa62bdddcf1d74d4e6b2521f8c10"
+GITHUB_RUNNER_VERSION=2.294.0
+GITHUB_RUNNER_CHECKSUM="a19a09f4eda5716e5d48ba86b6b78fc014880c5619b9dba4a059eaf65e131780"
 
 function install_githubrunner()
 {

--- a/tools/github_runner/remove.sh
+++ b/tools/github_runner/remove.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# To remove an installed runner,
+# Replace with your GitHub Runner Token
+# (change URL to your GitHub organization if you forked the application)
+# https://github.com/eclipse-pass/main/settings/actions/runners/new?arch=x64&os=linux
+#
+# GITHUB_RUNNER_TOKEN=AABBCCDDEEAABBCCDDEEAABBCCDDE ./remove.sh
+
+# You must provide this on the command line
+GITHUB_RUNNER_TOKEN=${GITHUB_RUNNER_TOKEN-na}
+
+(cd /opt/githubrunner && \
+  ./svc.sh uninstall githubrunner && \
+  sudo -u githubrunner ./config.sh remove --token $GITHUB_RUNNER_TOKEN)


### PR DESCRIPTION
The EF infra docs are here
https://github.com/eclipse-pass/main/blob/178-document-do-dev/docs/infra/eclipseops.md

The digital ocean docs are here
https://github.com/eclipse-pass/main/blob/178-document-do-dev/docs/infra/digitalocean.md

But also note the helper scripts which can be used for AWS EC2.