### PR TITLE
Updates project roadmap to prioritize Fedora replacement

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,19 +16,24 @@ This will be the initial release of the PASS codebase after transition to Eclips
 * Initial documentation - providing a starting point for development and deployment documenatation
 
 ## 0.2.0
-This release will focus on building consistency within the project codebase and enabling automation to simplify and speed the development process.
-* Harmonize Integration Test setup - updating the method for executing integration tests to ensure consistent and streamlined launch and execution
+This release will focus on the replacement of the primary data management system used to maintain application data and state.
+* Fedora 4 replacement - update the data management layer of the stack
+* PASS API enhancement - definition of the primary interface to sit in front of the new data management system
+
+## 1.0.0
+The first major release of the Eclipse PASS project will focus on stability by building consistency within the project codebase and enabling automation to simplify and speed the development process.
 * Harmonize Docker image generation - ensure Docker images are generated in a consistent way across all project components
 * Automating the maven release and docker image building process - introducing additional automation to ensure consistency and reduce effort in the release of Maven artifacts and the generation of Docker images
 * Verify consistent Java version - ensure all Java components and docker images require Java 11, as preparation to upgrade to more current Java versions
-
-## 1.0.0
-This release will include the replacement of a major system component, which is expected to simplify system interaction and increase performance. This will also be the first major release of the Eclipse PASS project.
-* Fedora 4 replacement - update the data management layer of the stack
-* Go project replacement - transition existing Go modules to use Java in order to unify the project codebase
 * Dependency updates - update project dependencies and introduce automated convergence checks
 
 ## 1.1.0
+This release will focus on setup and improvement of application testing environments as well as moving towards greater codebase language consistency.
+* Harmonize Integration Test setup - updating the method for executing integration tests to ensure consistent and streamlined launch and execution
+* Addition of system tests - adding a mechanism and tests to support full-system verification
+* Go project replacement - transition existing Go modules to use Java in order to unify the project codebase
+
+## 1.2.0
 This release will focus on ensuring that those operating and maintaining the PASS application have the information needed to visualize system activity
 * Logging improvement - ensure logging is configured, captured, and utilized consistently across the project
 * Monitoring and observability - define, capture, and expose metrics required for understanding performance, system utilization, and tracking errors


### PR DESCRIPTION
Reorganizes the PASS release plan based on the decision to focus on the Fedora replacement first, with integration test updates to follow. Note that this adds an additional release to the list after 1.0.0, to keep a distinction between a focus on testing and monitoring.

It may be easier to read/review the formatted version: https://github.com/eclipse-pass/main/blob/roadmap-update/docs/roadmap.md