### PR TITLE
Release details

### DIFF
--- a/docs/dev/integration-test-docker-dependencies.md
+++ b/docs/dev/integration-test-docker-dependencies.md
@@ -1,3 +1,5 @@
+**As of August 2022, all images used in ITs have been synced to the same versions: `0.1.0`**. The exception is the Elasticsearch image, which remained at `6.2.3`
+
 ## Current Integration Testing Docker Dependencies
 
 Java projects:
@@ -65,4 +67,6 @@ All projects use `6.2.3` 🎉
 Relationships for all Docker images, how they are used in various integration tests, and where they are built. Most images are built in `pass-docker` with the exception of four stand-alone services, which are built within their respective code repositories: [`pass-doi-services`](https://github.com/eclipse-pass/pass-doi-service), [`pass-metadata-schemas`](https://github.com/eclipse-pass/pass-metadata-schemas), [`pass-policy-service`](https://github.com/eclipse-pass/pass-policy-service), [`pass-download-service`](https://github.com/eclipse-pass/pass-download-service)
 
 ![Docker Image IT dependencies.png](/docs/assets/architecture/Docker%20Image%20IT%20dependencies.png)
+
+Original: https://www.figma.com/file/ibkDXjJ6AkXMpvPvL96gmi/Docker-Image-IT-dependencies?node-id=0%3A1
 

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -219,9 +219,9 @@ Image depdendency / usage diagram: https://www.figma.com/file/ibkDXjJ6AkXMpvPvL9
    * `mail`
    * `postgres`
    * `static-html`
-2. The `indexer` should be updated next. ITs for this code repository only rely on `fcrepo`, but the built Docker image is used in nearly all other set of integration tests.
+2. The `indexer` should be updated next. ITs for this code repository only rely on `fcrepo`, but the built Docker image is used in nearly all other sets of integration tests.
    * The ITs for `indexer` run against a custom docker-compose environment, which must be updated manually
-   * The `indexer` image should be updated the `eclipse-pass/main` POM
+   * The `indexer` image should be updated in the `eclipse-pass/main` POM
 3. The next set of project code ITs can be run to verify. All new images up to this point can be modified from the main POM and the versions will be inherited for tests:
 	  * `eclipse-pass/pass-java-client`
 	  * `eclipse-pass/pass-nihms-loader`
@@ -229,7 +229,7 @@ Image depdendency / usage diagram: https://www.figma.com/file/ibkDXjJ6AkXMpvPvL9
 	  * `eclipse-pass/pass-grant-loader`
 	  * `eclipse-pass/pass-notification-services`
 	  * `eclipse-pass/pass-authz`
-		  * Authz is a special case. Its ITs use `fcrepo` and `indexer` images. However, it wraps `fcrepo` in a custom built image where it injects it's own updated artifacts. Sequencing the update of this repository is very tricky and may require some iteration of images
+		  * Authz is a special case. Its ITs use `fcrepo` and `indexer` images. However, it wraps `fcrepo` in a custom built image where it injects its own updated artifacts. Sequencing the update of this repository is very tricky and may require some iteration of images
 	  * `eclipse-pass/pass-doi-service`
 	  * `eclipse-pass/pass-indexer-checker`
 	* Golang projects run ITs against custom docker-compose files which will have to be updated manually:

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -244,21 +244,7 @@ Image depdendency / usage diagram: https://www.figma.com/file/ibkDXjJ6AkXMpvPvL9
    * `doiservice`
    * `downloadservice`
 
-Note that deposit services is missing from this list. This should be handled last, as it takes some extra steps.
-
-### Handling Deposit Services
-Assume that `fcrepo` and `indexer` have already been updated, along with `ftpserver`, `dspace`
-1. Run a Maven build against `eclipse-pass/pass-deposit-services`: `mvn clean install`
-   This will create an intermediate image: `oapass/pass-deposit-core`
-   Tag and push this image || Do a Maven release to have it tagged and pushed automatically (`mvn clean deploy -P release`)
-2. Update the `docker.image.deposit-services-core.name` to match to match what you just built and pushed
-3. Run a Maven build against `eclipse-pass/pass-package-providers`: `mvn clean install`
-   This will use the image made in the previous step to produce a new image: `oapass/deposit-service-providers`
-   Tag and push this image || Do a Maven release to have it tagged and pushed automatically (`mvn clean deploy -P release`)
-4. Move to `eclipse-pass/pass-docker`
-   * Update the following build arg in the docker-compose file: `PROVIDERS_IMAGE` . The updated value should match the tag + hash of the `oapass/deposit-service-providers` from the previous step
-   * [[#Building a single image]]
-
+Note that deposit services is missing from this list. This should be handled separately, as it takes some extra steps.
 
 ---
 
@@ -278,7 +264,7 @@ Assume that `fcrepo` and `indexer` have already been updated, along with `ftpser
 
 ## Per-image customization
 
-Here's what you need to change manually before building a new image version in order to bring in code changes. If the docker-compose service is not mentioned here, you shouldn't need to make any manual changes.
+Here's what you need to change manually before building a new image version in order to bring in code changes. If the docker-compose service is not mentioned here, you shouldn't need to make any manual changes. All images must be built manually using docker-compose, following the [docker-compose rebuilding / updating](#docker-compose-rebuilding--updating) steps.
 
 #### `fcrepo`
 A new image is required if you there are code changes to: json-ld filters, jms-addons, authz core, (authz) user service, (authz) roles
@@ -297,8 +283,7 @@ A new image is required if you there are code changes to: json-ld filters, jms-a
 			* Authz roles: [Line 81](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L81-L82) (JAR URL) && [Line 83](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L83) (sha1 hash)
 			* User service: [Line 86](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L85-L86) (WAR URL) && [Line 87](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L87) (sha1 hash)
 
-2. [[#Building a single image]]: [Line 8](https://github.com/eclipse-pass/pass-docker/blob/main/docker-compose.yml#L8)
-
+2. [Building a single image](#Building-a-single-image): [Line 8](https://github.com/eclipse-pass/pass-docker/blob/main/docker-compose.yml#L8)
 
 #### `activemq`
 Should only need to be updated if updating the ActiveMQ version, which is only referenced as an [environment variable in the Dockerfile](https://github.com/eclipse-pass/pass-docker/blob/main/activemq/Dockerfile#L3).
@@ -310,20 +295,7 @@ In `.env`, update the value of `EMBER_GIT_BRANCH`. You can use the name of a tag
 In `.env` update the `STATIC_HTML_BRANCH` value. You can use a tag or commit hash
 
 #### `ftpserver`
-Shouldn't need to update, as this is intended to be only used during integration tests. Can re-tag the image by either rebuilding from the [Dockerfile](https://github.com/eclipse-pass/pass-docker/blob/main/ftpserver/Dockerfile) or [[#Retag without rebuild]]
-
-#### `proxy`
-Should be updated if updating the base image, or updating configs.
-
-#### `idp`
-#### `ldap`
-#### `sp`
-
-#### `dspace`
-Intended as an integration test stand-in for production DSpace.
-
-#### `postgres`
-Semi-custom image that supports `dspace` image. Used for integration tests.
+Shouldn't need to update, as this is intended to be only used during integration tests. Can re-tag the image by either rebuilding from the [Dockerfile](https://github.com/eclipse-pass/pass-docker/blob/main/ftpserver/Dockerfile) or [Retag without rebuild](#retag-without-rebuild)
 
 #### `indexer`
 * Update the `PI_VERSION` var in the Dockerfile
@@ -331,14 +303,11 @@ Semi-custom image that supports `dspace` image. Used for integration tests.
 * Update [sha1 hash](https://github.com/eclipse-pass/pass-docker/blob/main/indexer/Dockerfile#L15)
 * If necessary, update the `ESCONFIG_VERSION` var in the Dockerfile.
 
-#### `elasticsearch`
-External image, no rebuilding or retagging.
-
 #### `assets`
 ??
 
 #### `deposit`
-[[#Handling Deposit Services]]
+[Handling Deposit Services](Handling-Deposit-Services)
 
 #### `authz`
 For new Authz code release:
@@ -353,11 +322,6 @@ For new Authz code release:
 * Update [`NOTIFICATION_SERVICE_VERSION` var](https://github.com/eclipse-pass/pass-docker/blob/main/notification-services/0.1.0-3.4/Dockerfile#L3)
 * Update [`JSONLD_CONTEXT_VERSION`](https://github.com/eclipse-pass/pass-docker/blob/main/notification-services/0.1.0-3.4/Dockerfile#L4) if necessary
 * Update [artifact URL](https://github.com/eclipse-pass/pass-docker/blob/main/notification-services/0.1.0-3.4/Dockerfile#L24)
-
-#### `schemaservice`
-#### `policyservice`
-#### `doiservice`
-#### `downloadservice`
 
 # Testing
 

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -329,6 +329,15 @@ Manual testing can be done using the newly updated pass-docker to run the releas
 
 # Post Release
 
-  * Update release notes
+  * [Update release notes](#update-release-notes)
   * Update project documentation
   * Deploying the release
+
+
+### Update release notes
+
+1. Create a new label in GitHub issues by going to https://github.com/eclipse-pass/main/labels, selecting "New Label" and naming it "Release X.X.X" (using the new release number).
+2. Get a list of all issues that are closed and in the eclipse-pass project by going to: https://github.com/eclipse-pass/main/issues?page=1&q=is%3Aissue+is%3Aclosed+project%3Aeclipse-pass%2F4
+3. Apply the new label by selecting all, selecting the "Label" dropdown, and choosing the release label. If there are multiple pages of tickets, you'll need to do this on each page.
+4. Archive the release tickets in the Project by going to the Kanban Board https://github.com/orgs/eclipse-pass/projects/4/views/2, scrolling to the Done column, verifying that all tickets in the list have the new version tag, then selecting the ellipsis button and "Archive all cards"
+5. Include in the Release Notes a link to the issues resolved by the release, e.g. https://github.com/eclipse-pass/main/issues?q=label%3A%22Release+0.1.0%22

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -186,6 +186,179 @@ npm publish
 
 Each released image must be updated in the `pass-docker` `docker-compose.yml`. Each image is specified with a version and hash identifier. The versions should just be able to be updated to the new release version. The hash can be found using `docker inspect`.
 
+### Building a single image
+
+Updating a single image within [`pass-docker`](https://github.com/eclipse-pass/pass-docker) is largely done manually, for all images.
+
+* Remove the `@sha256:...` from the end of the `image` property for the service. Update the image tag. 
+	* Example: we want to update the current fcrepo image to `0.1.1`: `oapass/fcrepo:0.1.0@sha256:56730754843aec0a3d48bfcefd13d72f1bb34708aea9b47d2280d2da61a1eb54` would be changed to `oapass/fcrepo:0.1.1`
+* Specific to the service in question, you may need to update either an environment variable in the `.env` file or update the Dockerfile, or both. We'll break down the changes on a per-image basis later.
+* Build the image: `docker-compose build <service-name>`
+  For the fcrepo example above, you'd run `docker-compose build fcrepo`
+* Push the new image: `docker-compose push <service-name>`
+  Example above: `docker-compose push fcrepo`
+  This will return the hash that can be appended to the image property in the docker-compose file to pin the version, since Docker image tags can be overwritten at any time
+
+
+### Sequencing
+
+Image depdendency / usage diagram: https://www.figma.com/file/ibkDXjJ6AkXMpvPvL96gmi/Docker-Image-IT-dependencies?node-id=0%3A1
+
+1. The following images can be created in this step in any order. In other words, they don't have any direct dependence on other image nor do they have any testing dependence. For example, most of our Java projects depend on the `fcrepo` image when running integration tests, so that image should be updated before verifying those code repositories when cutting releases.
+   Once new images are built in this step, update their references in `eclipse-pass/main`. 
+   * `activemq`
+   * `assets`
+   * `dspace`
+   * `ember`
+   * `fcrepo`
+   * `ftpserver`
+   * `proxy`
+   * `idp`
+   * `ldap`
+   * `sp`
+   * `mail`
+   * `postgres`
+   * `static-html`
+2. The `indexer` should be updated next. ITs for this code repository only rely on `fcrepo`, but the built Docker image is used in nearly all other set of integration tests.
+   * The ITs for `indexer` run against a custom docker-compose environment, which must be updated manually
+   * The `indexer` image should be updated the `eclipse-pass/main` POM
+3. The next set of project code ITs can be run to verify. All new images up to this point can be modified from the main POM and the versions will be inherited for tests:
+	  * `eclipse-pass/pass-java-client`
+	  * `eclipse-pass/pass-nihms-loader`
+	  * `eclipse-pass/pass-journal-loader` - runs against custom docker-compose environment, must be updated manually
+	  * `eclipse-pass/pass-grant-loader`
+	  * `eclipse-pass/pass-notification-services`
+	  * `eclipse-pass/pass-authz`
+		  * Authz is a special case. Its ITs use `fcrepo` and `indexer` images. However, it wraps `fcrepo` in a custom built image where it injects it's own updated artifacts. Sequencing the update of this repository is very tricky and may require some iteration of images
+	  * `eclipse-pass/pass-doi-service`
+	  * `eclipse-pass/pass-indexer-checker`
+	* Golang projects run ITs against custom docker-compose files which will have to be updated manually:
+	   * `eclipse-pass/pass-metadata-schemas`
+	   * `eclipse-pass/pass-download-service`
+	   * `eclipse-pass/pass-policy-service`
+4. Publish a set of new images:  
+   * `authz`
+   * `notification`
+   * `schemaservice`
+   * `policyservice`
+   * `doiservice`
+   * `downloadservice`
+
+Note that deposit services is missing from this list. This should be handled last, as it takes some extra steps.
+
+### Handling Deposit Services
+Assume that `fcrepo` and `indexer` have already been updated, along with `ftpserver`, `dspace`
+1. Run a Maven build against `eclipse-pass/pass-deposit-services`: `mvn clean install`
+   This will create an intermediate image: `oapass/pass-deposit-core`
+   Tag and push this image || Do a Maven release to have it tagged and pushed automatically (`mvn clean deploy -P release`)
+2. Update the `docker.image.deposit-services-core.name` to match to match what you just built and pushed
+3. Run a Maven build against `eclipse-pass/pass-package-providers`: `mvn clean install`
+   This will use the image made in the previous step to produce a new image: `oapass/deposit-service-providers`
+   Tag and push this image || Do a Maven release to have it tagged and pushed automatically (`mvn clean deploy -P release`)
+4. Move to `eclipse-pass/pass-docker`
+   * Update the following build arg in the docker-compose file: `PROVIDERS_IMAGE` . The updated value should match the tag + hash of the `oapass/deposit-service-providers` from the previous step
+   * [[#Building a single image]]
+
+
+---
+
+## docker-compose rebuilding / updating
+1. Remove the `@sha256` hash from the end of the image reference
+2. Update the image tag to new tag
+3. `docker-compose build <service_name>`
+4. `docker-compose push <service_name>`: Copy the returned `sha256` hash
+5. Append the copied hash to the image reference
+
+## Retag without rebuild
+* Grab the `image` reference from the docker-compose file, *without the hash*. Ex: `oapass/docker-mailserver:20181105-1`
+* `docker pull <image>:<tag>`
+* `docker tag <image>:<old_tag> <image>:<new_tag>`
+* `docker push <image>:<new_tag>`
+* You can now update the docker-compose file with the new tag + hash
+
+## Per-image customization
+
+Here's what you need to change manually before building a new image version in order to bring in code changes. If the docker-compose service is not mentioned here, you shouldn't need to make any manual changes.
+
+#### `fcrepo`
+A new image is required if you there are code changes to: json-ld filters, jms-addons, authz core, (authz) user service, (authz) roles
+
+1. Update Dockerfile: [`/fcrepo/4.7.5/Dockerfile`](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile)
+	* Update the JSON-LD servlet filter:
+		* Maven Central: [Line 4](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L4) (version number)
+		* SNAPSHOT: [Line 73](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L73-L74) (artifact download URL) && [Line 75](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L75) (associated SHA1 hash)
+	* JMS addons:
+		* Maven Central: [Line 6](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L6) (version number)
+		* SNAPSHOT: [Line 95](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L95-L96) (artifact download URL) && [Line 97](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L97) (associated SHA1 hash)
+	* Update Authz codebase - `pass-authz-core`,  `pass-user-service`, and `pass-authz-roles` must have the same version number, as they are published from the same project
+		* Maven Central: [Line 5](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L5) (release version number)
+		* SNAPSHOT:
+			* Authz core: [Line 77](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L77-L78) (shaded JAR URL) && [Line 79](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L79) (sha1 hash)
+			* Authz roles: [Line 81](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L81-L82) (JAR URL) && [Line 83](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L83) (sha1 hash)
+			* User service: [Line 86](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L85-L86) (WAR URL) && [Line 87](https://github.com/eclipse-pass/pass-docker/blob/main/fcrepo/4.7.5/Dockerfile#L87) (sha1 hash)
+
+2. [[#Building a single image]]: [Line 8](https://github.com/eclipse-pass/pass-docker/blob/main/docker-compose.yml#L8)
+
+
+#### `activemq`
+Should only need to be updated if updating the ActiveMQ version, which is only referenced as an [environment variable in the Dockerfile](https://github.com/eclipse-pass/pass-docker/blob/main/activemq/Dockerfile#L3).
+
+#### `ember`
+In `.env`, update the value of `EMBER_GIT_BRANCH`. You can use the name of a tag or a specific commit hash here
+
+#### `static-html`
+In `.env` update the `STATIC_HTML_BRANCH` value. You can use a tag or commit hash
+
+#### `ftpserver`
+Shouldn't need to update, as this is intended to be only used during integration tests. Can re-tag the image by either rebuilding from the [Dockerfile](https://github.com/eclipse-pass/pass-docker/blob/main/ftpserver/Dockerfile) or [[#Retag without rebuild]]
+
+#### `proxy`
+Should be updated if updating the base image, or updating configs.
+
+#### `idp`
+#### `ldap`
+#### `sp`
+
+#### `dspace`
+Intended as an integration test stand-in for production DSpace.
+
+#### `postgres`
+Semi-custom image that supports `dspace` image. Used for integration tests.
+
+#### `indexer`
+* Update the `PI_VERSION` var in the Dockerfile
+* Update [artifact URL](https://github.com/eclipse-pass/pass-docker/blob/main/indexer/Dockerfile#L14)
+* Update [sha1 hash](https://github.com/eclipse-pass/pass-docker/blob/main/indexer/Dockerfile#L15)
+* If necessary, update the `ESCONFIG_VERSION` var in the Dockerfile.
+
+#### `elasticsearch`
+External image, no rebuilding or retagging.
+
+#### `assets`
+??
+
+#### `deposit`
+[[#Handling Deposit Services]]
+
+#### `authz`
+For new Authz code release:
+
+* Update[ `VERSION` var](https://github.com/eclipse-pass/pass-docker/blob/main/authz/Dockerfile#L2)
+* Update sha1 hash of the [`pass-authz-listener-<version>-exe.jar`](https://github.com/eclipse-pass/pass-docker/blob/main/authz/Dockerfile#L15)
+
+#### `mail`
+??
+
+#### `notification`
+* Update [`NOTIFICATION_SERVICE_VERSION` var](https://github.com/eclipse-pass/pass-docker/blob/main/notification-services/0.1.0-3.4/Dockerfile#L3)
+* Update [`JSONLD_CONTEXT_VERSION`](https://github.com/eclipse-pass/pass-docker/blob/main/notification-services/0.1.0-3.4/Dockerfile#L4) if necessary
+* Update [artifact URL](https://github.com/eclipse-pass/pass-docker/blob/main/notification-services/0.1.0-3.4/Dockerfile#L24)
+
+#### `schemaservice`
+#### `policyservice`
+#### `doiservice`
+#### `downloadservice`
+
 # Testing
 
 Manual testing can be done using the newly updated pass-docker to run the release locally.


### PR DESCRIPTION
Preview: https://github.com/eclipse-pass/main/blob/update-release-docs/docs/dev/release.md#update-pass-docker
Doesn't really cover the ordering of code releases

Looking for feedback especially on the sequencing of image releases