### PR TITLE
Rework eclipseops to be EF specific  and deploy_demo to be dev specific

### DIFF
--- a/docs/infra/deploy_demo.md
+++ b/docs/infra/deploy_demo.md
@@ -64,7 +64,7 @@ From here, you can run the application (any version of it)
 docker-compose up
 ```
 
-Please refer to the specifics of the [clipse Foundation infrastructure](/docs/infra/eclipseops.md)
+Please refer to the specifics of the [Eclipse Foundation infrastructure](/docs/infra/eclipseops.md)
 for the actual commands to run on a specific environment.  For example, this
 is the specific script that (currently) runs [demo.eclipse-pass.org](https://demo.eclipse-pass.org)
 

--- a/docs/infra/deploy_demo.md
+++ b/docs/infra/deploy_demo.md
@@ -1,33 +1,24 @@
-# Deploy to demo.eclipse-pass.org
+# Deploying a demo PASS system
 
-Our [demo.eclipse-pass.org](https://demo.eclipse-pass.org) system
-is currently not publically available.
+What follows are developer-oriented instructions about our
+[GitHub Self-Hosted Runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners)
+connected to [GitHub actions](https://github.com/features/actions)
+for automatable deploys of PASS demo system.
 
-## Deploy
+For information on actually deploying updates to a _running_ demo system
+such as [demo.eclipse-pass.org](https://demo.eclipse-pass.org)
+please refer to [Eclipse Foundation infrastructure](/docs/infra/eclipseops.md)
 
-From the [pass-docker](https://github.com/eclipse-pass/pass-docker) project
-you can view the available [actions](https://github.com/eclipse-pass/pass-docker/actions)
-including the [Deploy passdemo action](https://github.com/eclipse-pass/pass-docker/blob/main/.github/workflows/deploy_passdemo.yml)
+## Self-Hosted Demo Code
 
-![pass-docker actions](/docs/assets/demo/passdocker_actions.png)
-
-You can then [run the workflow](https://github.com/eclipse-pass/pass-docker/actions/workflows/deploy_passdemo.yml)
-
-![run workflow](/docs/assets/demo/run_workflow.png)
-
-And watch the deploy.
-
-![deployed actions](/docs/assets/demo/deploy_actions.png)
-
-## Demo Code
-
-The code is located in an (unfortunately) deeply nested structure at
+On a self-hosted server, the code is located in an (unfortunately) deeply nested structure at
 
 ```bash
 /opt/githubrunner/pass-docker/pass-docker/pass-docker
 ```
 
-The deploy will pull the latest code, as shown below
+On a [GitHub actions](https://github.com/features/actions) deploy,
+the latest code will be available at that location, as shown below.
 
 ```bash
 a2forward@nightly-pass:/opt/githubrunner/pass-docker/pass-docker/pass-docker$ git log -1
@@ -40,13 +31,26 @@ Date:   Wed Sep 21 10:49:42 2022 -0400
     Separate Kubernetes changes into new files
 ```
 
-## Nightly Code
+## Action Triggers
 
-There is also a [nightly action](https://github.com/eclipse-pass/pass-docker/blob/main/.github/workflows/deploy_passnightly.yml)
-that will run every night (and on every pull-request merge).
+The [GitHub actions](https://github.com/features/actions) are defined in
+[pass-docker/.github/workflows]((https://github.com/eclipse-pass/pass-docker/blob/main/.github/workflows/)
+such as our [nightly action](https://github.com/eclipse-pass/pass-docker/blob/main/.github/workflows/deploy_passnightly.yml).
 
-For debugging changes outside of an official deploy, you can
-directly manipulate code on the server.  You will need to run as `githubrunner`.
+The [nightly action](https://github.com/eclipse-pass/pass-docker/blob/main/.github/workflows/deploy_passnightly.yml)
+will run every night (and on every pull-request merge).
+
+## Debugging On The Server
+
+Please ensure the issue is actually related to the deployed environment
+and IS NOT reproducible locally.
+
+If you are troubleshooting strange behaviour on a
+[GitHub Self-Hosted Runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners)
+then you can directly manipulate the code outside of an official deploy.
+
+
+For that, first SSH onto that server, and then switch to the `githubrunner` user.
 
 ```bash
 # SSH into the server
@@ -54,13 +58,23 @@ cd /opt/githubrunner/pass-docker/pass-docker/pass-docker
 sudo su githubrunner
 ```
 
-And then you can run the application (if it isn't already)
+From here, you can run the application (any version of it)
 
 ```bash
 docker-compose up
 ```
 
-Or, perhaps change the branch and run a custom build.
+Please refer to the specifics of the [clipse Foundation infrastructure](/docs/infra/eclipseops.md)
+for the actual commands to run on a specific environment.  For example, this
+is the specific script that (currently) runs [demo.eclipse-pass.org](https://demo.eclipse-pass.org)
+
+```
+docker-compose -f eclipse-pass.base.yml -f eclipse-pass.demo.yml up
+```
+
+For debugging purposes you can also change the branch and run a
+specific build (what follows is for demonstration purposes not the
+specific commands you want to run)
 
 ```bash
 git fetch
@@ -69,7 +83,8 @@ docker-compose -f demo.yml pull
 docker-compose -f demo.yml --env-file .demo_env up
 ```
 
-And then you can (in a separate terminal) observe the working site
+If the application did launch as expected, you should be able to
+see the working site (for example using `curl`).
 
 ```bash
 curl -k https://localhost

--- a/docs/infra/eclipseops.md
+++ b/docs/infra/eclipseops.md
@@ -1,5 +1,97 @@
 # Eclipse Foundation Operations
 
+The following site are managed by the Eclipse Foundation.
+
+| URL | Notes | Status
+| --- | --- | --- |
+| eclipse-pass.org | Github Pages HTML / CSS | pending
+| demo.eclipse-pass.org | Linux + Docker Compose | pending
+| nightly.eclipse-pass.org | Linux + Docker Compose | pending
+
+If you are looking for developer-oriented instructions
+to help debug an issue with the above, please refer to
+[managing our demo servers](/docs/infra/deploy_demo.md) documentation.
+
+## Deployment
+
+### eclipse-pass.org
+
+This is managed with [GitHub Pages](https://pages.github.com)
+from the [eclipse-pass.github.io](https://github.com/eclipse-pass/eclipse-pass.github.io) repo.
+
+### demo.eclipse-pass.org
+
+The [demo.eclipse-pass.org](https://demo.eclipse-pass.org) site is deployed
+on demand using [GitHub actions](https://github.com/features/actions).
+Note that this site is not yet publically available.
+
+The demo system is based on the [pass-docker](https://github.com/eclipse-pass/pass-docker) project
+and you can view the available [actions](https://github.com/eclipse-pass/pass-docker/actions)
+including the [Deploy passdemo action](https://github.com/eclipse-pass/pass-docker/blob/main/.github/workflows/deploy_passdemo.yml)
+
+#### Publish Via GitHub.com
+
+To publish an update, access the actions page.
+
+![pass-docker actions](/docs/assets/demo/passdocker_actions.png)
+
+You can then [run the workflow](https://github.com/eclipse-pass/pass-docker/actions/workflows/deploy_passdemo.yml)
+
+![run workflow](/docs/assets/demo/run_workflow.png)
+
+And watch the deploy.
+
+![deployed actions](/docs/assets/demo/deploy_actions.png)
+
+#### Locally Run Via Docker Compose
+
+The [demo.eclipse-pass.org](https://demo.eclipse-pass.org) site is
+managed using [Docker Commpose](https://docs.docker.com/compose/).
+
+To run locally first get a locak copy of [pass-docker](https://github.com/eclipse-pass/pass-docker)
+then run it with the following commands
+
+```
+cd pass-docker && \
+  docker-compose -f eclipse-pass.base.yml -f eclipse-pass.demo.yml pull && \
+  docker-compose -f eclipse-pass.base.yml -f eclipse-pass.demo.yml up
+```
+
+For more information debugging the deployment to our demo servers
+please refer to our [demo deploy documentation](/docs/infra/deploy_demo.md).
+
+### nightly.eclipse-pass.org
+
+The [nightly.eclipse-pass.org](https://demo.eclipse-pass.org) site is deployed
+automatically on PR merged (as well as nightly) using [GitHub actions](https://github.com/features/actions).
+Note that this site is not yet publically available.
+
+Much like [demo.eclipse-pass.org](https://demo.eclipse-pass.org) the nightly
+system is based on the [pass-docker](https://github.com/eclipse-pass/pass-docker) project
+and you can view the available [actions](https://github.com/eclipse-pass/pass-docker/actions)
+including the [Deploy passdemo action](https://github.com/eclipse-pass/pass-docker/blob/main/.github/workflows/deploy_passdemo.yml)
+
+#### Locally Run Via Docker Compose
+
+The [nightly.eclipse-pass.org](https://nightly.eclipse-pass.org) site is
+managed using [Docker Commpose](https://docs.docker.com/compose/).
+
+To run locally first get a locak copy of [pass-docker](https://github.com/eclipse-pass/pass-docker)
+then run it with the following commands
+
+```
+cd pass-docker && \
+  docker-compose -f eclipse-pass.base.yml -f eclipse-pass.nightly.yml pull && \
+  docker-compose -f eclipse-pass.base.yml -f eclipse-pass.nightly.yml up
+```
+
+For more information debugging the deployment to our demo servers
+(such as [nightly.eclipse-pass.org](https://nightly.eclipse-pass.org))
+please refer to our [demo deploy documentation](/docs/infra/deploy_demo.md).
+
+
+## Infrastructure
+
 A bootstrapped server [installer](/tools/eclipse_ops/bootstrap)
 to run a stand-alone PASS application via the [pass-docker](https://github.com/eclipse-pass/pass-docker)
 project

--- a/docs/infra/eclipseops.md
+++ b/docs/infra/eclipseops.md
@@ -48,7 +48,7 @@ And watch the deploy.
 The [demo.eclipse-pass.org](https://demo.eclipse-pass.org) site is
 managed using [Docker Compose](https://docs.docker.com/compose/).
 
-To run locally first get a locak copy of [pass-docker](https://github.com/eclipse-pass/pass-docker)
+To run locally first get a local copy of [pass-docker](https://github.com/eclipse-pass/pass-docker)
 then run it with the following commands
 
 ```
@@ -76,7 +76,7 @@ including the [Deploy passdemo action](https://github.com/eclipse-pass/pass-dock
 The [nightly.eclipse-pass.org](https://nightly.eclipse-pass.org) site is
 managed using [Docker Compose](https://docs.docker.com/compose/).
 
-To run locally first get a locak copy of [pass-docker](https://github.com/eclipse-pass/pass-docker)
+To run locally first get a local copy of [pass-docker](https://github.com/eclipse-pass/pass-docker)
 then run it with the following commands
 
 ```

--- a/docs/infra/eclipseops.md
+++ b/docs/infra/eclipseops.md
@@ -46,7 +46,7 @@ And watch the deploy.
 #### Locally Run Via Docker Compose
 
 The [demo.eclipse-pass.org](https://demo.eclipse-pass.org) site is
-managed using [Docker Commpose](https://docs.docker.com/compose/).
+managed using [Docker Compose](https://docs.docker.com/compose/).
 
 To run locally first get a locak copy of [pass-docker](https://github.com/eclipse-pass/pass-docker)
 then run it with the following commands
@@ -74,7 +74,7 @@ including the [Deploy passdemo action](https://github.com/eclipse-pass/pass-dock
 #### Locally Run Via Docker Compose
 
 The [nightly.eclipse-pass.org](https://nightly.eclipse-pass.org) site is
-managed using [Docker Commpose](https://docs.docker.com/compose/).
+managed using [Docker Compose](https://docs.docker.com/compose/).
 
 To run locally first get a locak copy of [pass-docker](https://github.com/eclipse-pass/pass-docker)
 then run it with the following commands


### PR DESCRIPTION
This doc talks specifically about EF infra
https://github.com/eclipse-pass/main/blob/294-demo-and-nightly/docs/infra/eclipseops.md

This doc is more developer focussed on how to debug our GH actions and self-hosted runners that run our demo servers
https://github.com/eclipse-pass/main/blob/294-demo-and-nightly/docs/infra/deploy_demo.md