### PR TITLE
Add troubleshooting instructions on working on the eclipse demo servers

### DIFF
--- a/docs/infra/eclipseops.md
+++ b/docs/infra/eclipseops.md
@@ -176,3 +176,18 @@ For example, to stop all `demo` services run,
 ```
 docker-compose -f eclipse-pass.base.yml -f eclipse-pass.demo.yml down
 ```
+
+### Remove Rogue Processes
+
+If the docker-compose file has drastically changed, then there migth be _rogue_ processes
+still running.  You can view them with
+
+```bash
+docker ps
+```
+
+Then grab the container IDs and manually stop them.
+
+```bash
+docker stop 03159019094f
+```

--- a/docs/infra/eclipseops.md
+++ b/docs/infra/eclipseops.md
@@ -140,6 +140,9 @@ sudo docker-compose up -d
 ### Access Eclipse Servers
 
 To access the Eclipse infrastructure you will need a `bastion.eclipse.org` login.
+If you do not have a `bastion` login, then you will need to reach out to
+a [team member](https://github.com/orgs/eclipse-pass/teams/technology-pass-committers/members)
+for instructions (and permission) to get such a login.
 
 | Server | IP |
 | --- | --- |

--- a/docs/infra/eclipseops.md
+++ b/docs/infra/eclipseops.md
@@ -134,3 +134,45 @@ If you want to run in the background then use `-d`.
 ```bash
 sudo docker-compose up -d
 ```
+
+## Troubleshooting
+
+### Access Eclipse Severs
+
+To access the Eclipse infrastructure you will need a `bastion.eclipse.org` login.
+
+| Server | IP |
+| --- | --- |
+| nightly.eclipse-pass.org | ssh ${ME}@bastion.eclipse.org -t ssh ${ME}@172.30.206.14
+| demo.eclipse-pass.org | ssh ${ME}@bastion.eclipse.org -t ssh ${ME}@172.30.206.15
+
+You will need to change `ME` to your username
+
+```bash
+ME=myusername
+```
+
+Once on the server, then CD into the directory and change to the `githubrunner` user
+
+```bash
+cd /opt/githubrunner/pass-docker/pass-docker/pass-docker
+sudo su githubrunner
+```
+
+Now you have full access to the application and can run the application as shown below
+
+### Run Remote Apps
+
+From our [GitHub actions](https://github.com/features/actions) you will see
+the specifics on running the servers
+
+| Server | Configs | Runner |
+| --- | --- | --- |
+| nightly.eclipse-pass.org | `docker-compose -f eclipse-pass.base.yml -f eclipse-pass.nightly.yml` | [nightly script](https://github.com/eclipse-pass/pass-docker/blob/main/.github/workflows/deploy_passnightly.yml)
+| demo.eclipse-pass.org | `docker-compose -f eclipse-pass.base.yml -f eclipse-pass.demo.yml`  | [demo script](https://github.com/eclipse-pass/pass-docker/blob/main/.github/workflows/deploy_passdemo.yml)
+
+For example, to stop all `demo` services run,
+
+```
+docker-compose -f eclipse-pass.base.yml -f eclipse-pass.demo.yml down
+```

--- a/docs/infra/eclipseops.md
+++ b/docs/infra/eclipseops.md
@@ -143,8 +143,8 @@ To access the Eclipse infrastructure you will need a `bastion.eclipse.org` login
 
 | Server | IP |
 | --- | --- |
-| nightly.eclipse-pass.org | ssh ${ME}@bastion.eclipse.org -t ssh ${ME}@172.30.206.14
-| demo.eclipse-pass.org | ssh ${ME}@bastion.eclipse.org -t ssh ${ME}@172.30.206.15
+| nightly.eclipse-pass.org | `ssh ${ME}@bastion.eclipse.org -t ssh ${ME}@172.30.206.14`
+| demo.eclipse-pass.org | `ssh ${ME}@bastion.eclipse.org -t ssh ${ME}@172.30.206.15`
 
 You will need to change `ME` to your username
 

--- a/docs/infra/eclipseops.md
+++ b/docs/infra/eclipseops.md
@@ -137,7 +137,7 @@ sudo docker-compose up -d
 
 ## Troubleshooting
 
-### Access Eclipse Severs
+### Access Eclipse Servers
 
 To access the Eclipse infrastructure you will need a `bastion.eclipse.org` login.
 


### PR DESCRIPTION
Although the EF infra is not available to everyone, I wanted to document the troubleshooting that I do so that if others take over then can have a cheat sheet to investigate issues and test changes.

Preview of changes
https://github.com/eclipse-pass/main/blob/f/eclipse-ops-troubleshooting/docs/infra/eclipseops.md#troubleshooting
