### PR TITLE
Upgrade to 2.12.2 docker-compose

### DIFF
--- a/tools/eclipse_ops/bootstrap
+++ b/tools/eclipse_ops/bootstrap
@@ -13,6 +13,7 @@ GITHUB_ORG=eclipse-pass
 GITHUB_PROJECT_URL=https://github.com/${GITHUB_ORG}/pass-docker
 GITHUB_PROJECT_GIT=https://github.com/${GITHUB_ORG}/pass-docker.git
 GITHUB_RUNNER_LABEL=passnightly
+DOCKER_COMPOSE_VERSION=2.12.2
 
 # Then copy and paste the bootstrap code
 #
@@ -36,7 +37,11 @@ function go() {
 function install_docker() {
   touch /opt/docker.start && \\
     apt-get -y update && \\
-    apt-get install -y gnupg2 pass docker-compose && \\
+    apt-get install -y gnupg2 pass docker.io && \\
+    curl -L \"https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-\$(uname -s)-\$(uname -m)\" -o /usr/local/bin/docker-compose && \\
+    chmod +x /usr/local/bin/docker-compose && \\
+    docker --version && \\
+    docker-compose --version && \\
     mv /opt/docker.start /opt/docker.end
 }
 

--- a/tools/eclipse_ops/m1_upgrade_docker_compose
+++ b/tools/eclipse_ops/m1_upgrade_docker_compose
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Then copy and paste the migration code
+#
+# Ideally we would SCP the file, but I was not able
+# to get a two-hop working between
+# bastion.eclipse.org and the individual servers
+
+DOCKER_COMPOSE_VERSION=2.12.2
+
+echo '#!/bin/bash' > /tmp/m1.sh
+
+printf "%b" "
+function go() {
+  touch /opt/m1.start && \\
+    uninstall_docker_compose && \\
+    install_docker_compose && \\
+    mv /opt/m1.start /opt/m1.end
+}
+
+function uninstall_docker_compose() {
+  touch /opt/uninstall_docker_compose.start && \\
+    apt remove -y docker-compose && \\
+    mv /opt/uninstall_docker_compose.start /opt/uninstall_docker_compose.end
+}
+
+function install_docker_compose() {
+  touch /opt/docker_compose.start && \\
+    curl -L \"https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-\$(uname -s)-\$(uname -m)\" -o /usr/local/bin/docker-compose && \\
+    chmod +x /usr/local/bin/docker-compose && \\
+    docker --version && \\
+    docker-compose --version && \\
+    mv /opt/docker_compose.start /opt/docker_compose.end
+}
+
+go
+
+" >> /tmp/m1.sh
+
+chmod 755 /tmp/m1.sh
+
+sudo /tmp/m1.sh


### PR DESCRIPTION
Deployed to demo.eclipse-pass.org and nightly.eclipse-pass.org

```
a2forward@demo:~$ docker --version
Docker version 20.10.7, build 20.10.7-0ubuntu5.1
a2forward@demo:~$ docker-compose --version
Docker Compose version v2.12.2
```