### PR TITLE
POM cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,58 +80,11 @@
     <spring-boot-maven-plugin.version>2.1.2.RELEASE</spring-boot-maven-plugin.version>
     <tidy-maven-plugin.version>1.1.0</tidy-maven-plugin.version>
 
-    <!-- PASS dependency versions -->
-    <pass-authz.version>${project.version}</pass-authz.version>
-    <pass-deposit-services.version>${project.version}</pass-deposit-services.version>
-    <pass-doi-service.version>${project.version}</pass-doi-service.version>
-    <pass-fcrepo-jms.version>${project.version}</pass-fcrepo-jms.version>
-    <pass-fcrepo-jsonld.version>${project.version}</pass-fcrepo-jsonld.version>
-    <pass-grant-loader.version>${project.version}</pass-grant-loader.version>
-    <pass-indexer.version>${project.version}</pass-indexer.version>
-    <pass-indexer-checker.version>${project.version}</pass-indexer-checker.version>
-    <pass-java-client.version>${project.version}</pass-java-client.version>
-    <pass-journal-loader.version>${project.version}</pass-journal-loader.version>
-    <pass-messaging-support.version>${project.version}</pass-messaging-support.version>
-    <pass-nihms-loader.version>${project.version}</pass-nihms-loader.version>
-    <pass-notification-services.version>${project.version}</pass-notification-services.version>
-    <pass-package-providers.version>${project.version}</pass-package-providers.version>
-
     <checkstyle.version>8.41.1</checkstyle.version>
     <duraspace-codestyle.version>1.1.0</duraspace-codestyle.version>
     <logback.version>1.2.11</logback.version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j2.version>2.14.1</log4j2.version>
-
-    <!-- Docker images for ITs -->
-    <it.image.fcrepo.name>
-      oapass/fcrepo:0.1.0@sha256:56730754843aec0a3d48bfcefd13d72f1bb34708aea9b47d2280d2da61a1eb54
-    </it.image.fcrepo.name>
-    <it.image.indexer.name>
-      oapass/indexer:0.1.0@sha256:5ad45a9d227d9e48a607d9344b72a6bf9eeb66388a8088794bdbd5e4eab5de2d
-    </it.image.indexer.name>
-    <it.image.elasticsearch.name>
-      docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3
-    </it.image.elasticsearch.name>
-    <it.image.mail.name>
-      oapass/docker-mailserver:20181105-1@sha256:5be8a080a8f7d70c3d8a315f2241ca49ea9051c9efbb940a9099cf64f2bf975d
-    </it.image.mail.name>
-    <it.image.ldap.name>
-      oapass/ldap:0.1.0@sha256:fd66cb1255b81b81ae602d1ccf56d8534e80a6ee27bccc1de014efab58cbf28c
-    </it.image.ldap.name>
-    <it.image.ftp.name>
-      oapass/ftpserver:0.1.0@sha256:f095b1944aca9c7dd8f68641f682dcba36a0d779b3ba8cb79475a84e4632ab57
-    </it.image.ftp.name>
-    <it.image.dspace.name>
-      oapass/dspace:0.1.0@sha256:ffb21fc796f0ff0149fe89958c0cc425826325b96b2b8336522b9028e44876c9
-    </it.image.dspace.name>
-    <it.image.postgres.name>
-      oapass/postgres:0.1.0@sha256:ace6225676b8da663fb3eff8de7b0d21ff5fec564875b108580fb16e31573711
-    </it.image.postgres.name>
-    
-    <!-- Intermediate image used when creating new package-provider images -->
-    <docker.image.deposit-services-core.name>
-      oapass/deposit-services-core:0.1.0@sha256:cef627bd720350108ab3e17111d3d7513d121955f3f0cbd9180215ecd0929791
-    </docker.image.deposit-services-core.name>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -55,29 +55,31 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+    <!-- Deposit Services (and related) props
+      <git-commit-plugin.version>2.2.4</git-commit-plugin.version>
+      <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+      <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
+      <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
+      <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+      <maven-shade-plugin.version>3.2.3</maven-shade-plugin.version>
+      <spring-boot-maven-plugin.version>2.1.2.RELEASE</spring-boot-maven-plugin.version>
+    -->
+
     <!-- Plugin versions -->
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     <docker-maven-plugin.version>0.40.1</docker-maven-plugin.version>
-    <git-commit-plugin.version>2.2.4</git-commit-plugin.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
     <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
-    <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-    <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
-    <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
-    <maven-shade-plugin.version>3.2.3</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven.spring.plugin.version>2.7.4</maven.spring.plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
-    <spring-boot-maven-plugin.version>2.1.2.RELEASE</spring-boot-maven-plugin.version>
     <tidy-maven-plugin.version>1.1.0</tidy-maven-plugin.version>
 
     <checkstyle.version>8.41.1</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -239,12 +239,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
-            <!--
-              When migrating to Java 11, remove <source> and <target> and replace with
-              <release>11</release>
-              -->
+            <source>11</source>
+            <target>11</target>
           </configuration>
         </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -55,16 +55,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- Deposit Services (and related) props
-      <git-commit-plugin.version>2.2.4</git-commit-plugin.version>
-      <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-      <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
-      <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
-      <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
-      <maven-shade-plugin.version>3.2.3</maven-shade-plugin.version>
-      <spring-boot-maven-plugin.version>2.1.2.RELEASE</spring-boot-maven-plugin.version>
-    -->
-
     <!-- Plugin versions -->
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     <docker-maven-plugin.version>0.40.1</docker-maven-plugin.version>
@@ -87,6 +77,10 @@
     <logback.version>1.2.11</logback.version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j2.version>2.14.1</log4j2.version>
+    <spring.version>2.5.6</spring.version>
+    <okhttp.version>4.10.0</okhttp.version>
+    <junit.jupiter.version>5.9.2</junit.jupiter.version>
+    <elide.version>6.1.8</elide.version>
   </properties>
 
   <dependencyManagement>
@@ -126,6 +120,16 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-compiler-plugin.version}</version>
+          <configuration>
+            <source>11</source>
+            <target>11</target>
+          </configuration>
+        </plugin>
+
         <!-- Used to validate all code style rules in source code using Checkstyle -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -237,16 +241,84 @@
         </plugin>
 
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>${maven-compiler-plugin.version}</version>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>${maven-gpg-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
           <configuration>
-            <source>11</source>
-            <target>11</target>
+            <useAgent>true</useAgent>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${maven-source-plugin.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${maven-javadoc-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+              <configuration>
+                <quiet>true</quiet>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+	
+        <plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>${docker-maven-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${build-helper-maven-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-failsafe-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>${maven-war-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -274,51 +346,6 @@
     <profile>
       <id>release</id>
       <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <artifactId>maven-gpg-plugin</artifactId>
-              <version>${maven-gpg-plugin.version}</version>
-              <executions>
-                <execution>
-                  <id>sign-artifacts</id>
-                  <phase>verify</phase>
-                  <goals>
-                    <goal>sign</goal>
-                  </goals>
-                </execution>
-              </executions>
-              <configuration>
-                <useAgent>true</useAgent>
-              </configuration>
-            </plugin>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-source-plugin</artifactId>
-              <version>${maven-source-plugin.version}</version>
-              <executions>
-                <execution>
-                  <goals>
-                    <goal>jar</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-javadoc-plugin</artifactId>
-              <version>${maven-javadoc-plugin.version}</version>
-              <executions>
-                <execution>
-                  <id>attach-javadocs</id>
-                  <goals>
-                    <goal>jar</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-        </pluginManagement>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Related: #436 

## Changes

* Remove a set of properties that were only used in the old FCREPO based environments
* Bumped Java build version from 8 to 11
* Consolidated a set of properties and pluginManagement from `pass-core` and `pass-support` in the main POM, allowing us to remove them from those projects
  * One consequence of the property consolidation is that the `pass-core` test dependency on `junit-jupiter.version` will be changed from `5.5.2` to `5.9.2`. Local testing passed fine after this change

Some work on child projects after this would be merged: pluginManagement sections largely and some properties were taken out of pass-core and pass-support POMs and put into this the project main POM in this PR. I do have pending changes locally for these projects, but will wait until this PR is reviewed and merged before pushing those.

## Testing

I was able to run `mvn clean install` on this project to create a fresh local install of the updates, then was able to run the same in pass-core and pass-support successfully