### PR TITLE
Make all docs references relative

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,17 +4,17 @@ All documentation should be written within this [main repo](https://github.com/e
 or referenced here.  For example, please include links (with a small description) to
 any relevant websites, external references, and other cloud storages (e.g. Google Docs).
 
-* [Developer documentation](/docs/dev)
-* [Deployment and Infrastructure](/docs/infra)
-* [User documentation](/docs/user)
+* [Developer documentation](dev)
+* [Deployment and Infrastructure](infra)
+* [User documentation](user)
 * [Project Roadmap](roadmap.md)
 
 ## Articles of Interest
 
-* [Setting up a local instance of the PASS demo](/docs/dev/local_demo.md)
-* [How to deploy to demo.eclipse-pass.org](/docs/infra/deploy_demo.md)
-* [Working with GitHub secrets](/docs/infra/github-secrets.md)
-* [Troubleshooting dev issues](/docs/dev/troubleshooting.md)
-* [Deployment Pipeline](/docs/infra/pipeline.md)
-* [PASS via EC2](/docs/infra/ec2.md)
-* [PASS via Digital Ocean](/docs/infra/digitalocean.md)
+* [Setting up a local instance of the PASS demo](dev/local_demo.md)
+* [How to deploy to demo.eclipse-pass.org](infra/deploy_demo.md)
+* [Working with GitHub secrets](infra/github-secrets.md)
+* [Troubleshooting dev issues](dev/troubleshooting.md)
+* [Deployment Pipeline](infra/pipeline.md)
+* [PASS via EC2](infra/ec2.md)
+* [PASS via Digital Ocean](infra/digitalocean.md)

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,6 +1,6 @@
 # Developer Documentation
 
-Developer focused documentation should be written in this `docs/dev/` directory. Separate documentation pages can be added in this directory and referenced here. If a given component has many documentation pages, please add a directory for it within the [docs/dev/](/docs/dev) directory.
+Developer focused documentation should be written in this `docs/dev/` directory. Separate documentation pages can be added in this directory and referenced here. If a given component has many documentation pages, please add a directory for it within the [docs/dev/](.) directory.
 
 ## Development Guidelines
 
@@ -26,10 +26,10 @@ Only Committers on the PASS Eclipse project are able to make changes to the code
 
 ## Articles
 
-* [PASS Demo Setup](/docs/dev/local_demo.md) - Setting Up a Local Demo System
-* [PASS Parent POM](/docs/dev/parent-pom.md) - Common deps between Java projects
-* [PASS Playground](/docs/dev/playground.md) - Ops playground
-* [PASS UI](/docs/dev/pass-ui.md) - PASS Ember application
-* [Troubleshooting](/docs/dev/troubleshooting.md) - Common errors and how to fix them
-* [Docker Dependencies](/docs/dev/integration-test-docker-dependencies.md) - Integration Testing and Docker Dependencies
-* [Components](/docs/dev/components.md) - PASS project components
+* [PASS Demo Setup](local_demo.md) - Setting Up a Local Demo System
+* [PASS Parent POM](parent-pom.md) - Common deps between Java projects
+* [PASS Playground](playground.md) - Ops playground
+* [PASS UI](pass-ui.md) - PASS Ember application
+* [Troubleshooting](troubleshooting.md) - Common errors and how to fix them
+* [Docker Dependencies](integration-test-docker-dependencies.md) - Integration Testing and Docker Dependencies
+* [Components](components.md) - PASS project components

--- a/docs/dev/components.md
+++ b/docs/dev/components.md
@@ -50,5 +50,5 @@ The following repositories have been forked from others
 
 Dependency tree for the Java components in PASS.
 
-![Java component hierarchy](/docs/assets/java_project_hierarchy.png)
+![Java component hierarchy](../assets/java_project_hierarchy.png)
 

--- a/docs/dev/integration-test-docker-dependencies.md
+++ b/docs/dev/integration-test-docker-dependencies.md
@@ -66,7 +66,7 @@ All projects use `6.2.3` 🎉
 
 Relationships for all Docker images, how they are used in various integration tests, and where they are built. Most images are built in `pass-docker` with the exception of four stand-alone services, which are built within their respective code repositories: [`pass-doi-services`](https://github.com/eclipse-pass/pass-doi-service), [`pass-metadata-schemas`](https://github.com/eclipse-pass/pass-metadata-schemas), [`pass-policy-service`](https://github.com/eclipse-pass/pass-policy-service), [`pass-download-service`](https://github.com/eclipse-pass/pass-download-service)
 
-![Docker Image IT dependencies.png](/docs/assets/architecture/Docker%20Image%20IT%20dependencies.png)
+![Docker Image IT dependencies.png](../assets/architecture/Docker%20Image%20IT%20dependencies.png)
 
 Original: https://www.figma.com/file/ibkDXjJ6AkXMpvPvL96gmi/Docker-Image-IT-dependencies?node-id=0%3A1
 

--- a/docs/dev/local_demo.md
+++ b/docs/dev/local_demo.md
@@ -103,15 +103,15 @@ loader exited with code 0
 
 In your browser, navigate to [pass.local](https://pass.local).
 
-![Welcome to PASS](/docs/assets/passapp/welcome_screen.png)
+![Welcome to PASS](../assets/passapp/welcome_screen.png)
 
 You can click on login and enter `nih-user` / `moo`.
 
-![Login as nih-user / moo](/docs/assets/passapp/login_nih-user_moo.png)
+![Login as nih-user / moo](../assets/passapp/login_nih-user_moo.png)
 
 And then you are authenticated and can view the PASS dashboard.
 
-![PASS dashbaord](/docs/assets/passapp/dashboard.png)
+![PASS dashbaord](../assets/passapp/dashboard.png)
 
 
 ## Shutting down the demo

--- a/docs/dev/playground.md
+++ b/docs/dev/playground.md
@@ -27,7 +27,7 @@ docker run -p 8080:80 html-app
 
 And then you can visit http://127.0.0.1:8080
 
-![HTML App running in browser](/docs/assets/html_app_nginx.png)
+![HTML App running in browser](../assets/html_app_nginx.png)
 
 ## EmberJS Application
 
@@ -101,7 +101,7 @@ Babel: @ember-data/store (2)                  | 279ms (139 ms)
 
 And then you can visit http://127.0.0.1:4200
 
-![EmberJS App running in browser](/docs/assets/emberjs_app.png)
+![EmberJS App running in browser](../assets/emberjs_app.png)
 
 ### Testing the application
 

--- a/docs/infra/README.md
+++ b/docs/infra/README.md
@@ -2,7 +2,7 @@
 
 At a high level, PASS is decomposed into the following parts:
 
-![PASS Architecture V1](/docs/assets/architecture/pass-architecture-simple-v2.jpg)
+![PASS Architecture V1](../assets/architecture/pass-architecture-simple-v2.jpg)
 
 ### Infrastructure
 
@@ -12,7 +12,7 @@ The following describes the current PASS Infrastructure.
 
 EC2 virtual machines provide access to internal resources within the AWS VPC.
 
-Learn more about [deploying pass-docker via EC2](/docs/infra/ec2.md).
+Learn more about [deploying pass-docker via EC2](ec2.md).
 
 #### ECS
 
@@ -69,13 +69,13 @@ We will soon be upgrading our initial production instance (which is based on Fed
 
 ## Going Forward
 
-As we move towards an Eclipse Foundation hosted Open-Access PASS there will be changes to the PASS architecture, changes to the infrastructure, and changes to the deployment process. This will be documented here, as well as within our [PASS Development Pipeline](/docs/infra/pipeline.md).
+As we move towards an Eclipse Foundation hosted Open-Access PASS there will be changes to the PASS architecture, changes to the infrastructure, and changes to the deployment process. This will be documented here, as well as within our [PASS Development Pipeline](pipeline.md).
 
 ## References
 
-* [Deployment Pipeline](/docs/infra/pipeline.md)
-* [Our attempt to use Komposer to migrate Docker Compose to k8s manifest](/docs/infra/docker-composer-to-k8s-manifest.md)
-* [Working with GitHub secrets](/docs/infra/github-secrets.md)
-* [Self-Hosted GitHub Runners](/docs/infra/self_hosted_github_runners.md)
-* [Eclipse Foundation ops](/docs/infra/eclipseops.md)
-* [Ansible](/docs/infra/ansible.md)
+* [Deployment Pipeline](pipeline.md)
+* [Our attempt to use Komposer to migrate Docker Compose to k8s manifest](docker-composer-to-k8s-manifest.md)
+* [Working with GitHub secrets](github-secrets.md)
+* [Self-Hosted GitHub Runners](self_hosted_github_runners.md)
+* [Eclipse Foundation ops](eclipseops.md)
+* [Ansible](ansible.md)

--- a/docs/infra/deploy_demo.md
+++ b/docs/infra/deploy_demo.md
@@ -7,7 +7,7 @@ for automatable deploys of PASS demo system.
 
 For information on actually deploying updates to a _running_ demo system
 such as [demo.eclipse-pass.org](https://demo.eclipse-pass.org)
-please refer to [Eclipse Foundation infrastructure](/docs/infra/eclipseops.md)
+please refer to [Eclipse Foundation infrastructure](eclipseops.md)
 
 ## Self-Hosted Demo Code
 
@@ -64,7 +64,7 @@ From here, you can run the application (any version of it)
 docker-compose up
 ```
 
-Please refer to the specifics of the [Eclipse Foundation infrastructure](/docs/infra/eclipseops.md)
+Please refer to the specifics of the [Eclipse Foundation infrastructure](eclipseops.md)
 for the actual commands to run on a specific environment.  For example, this
 is the specific script that (currently) runs [demo.eclipse-pass.org](https://demo.eclipse-pass.org)
 

--- a/docs/infra/digitalocean.md
+++ b/docs/infra/digitalocean.md
@@ -1,7 +1,7 @@
 # PASS Digital Ocean Deployment
 
 This will document how to run PASS in [Digital Ocean](https://www.digitalocean.com)
-as [Self-Hosted GitHub Runners](/docs/infra/self_hosted_github_runners.md).
+as [Self-Hosted GitHub Runners](self_hosted_github_runners.md).
 
 ## Create Server
 
@@ -49,7 +49,7 @@ cd /src/pass-docker && \
 ## Install GitHub Runner Scripts
 
 If you also wanted to use this server as a
-[self-Hosted GitHub Runners software](/docs/infra/self_hosted_github_runners.md)
+[self-Hosted GitHub Runners software](self_hosted_github_runners.md)
 then run
 
 ```bash

--- a/docs/infra/eclipseops.md
+++ b/docs/infra/eclipseops.md
@@ -17,7 +17,7 @@ The underlying infrastructure for each is documented here
 
 If you are looking for more detailed developer-oriented instructions
 to help debug an issue with the above, please refer to
-[managing our demo servers](/docs/infra/deploy_demo.md) documentation.
+[managing our demo servers](deploy_demo.md) documentation.
 
 ## Deployment
 
@@ -35,7 +35,7 @@ information about PASS that we currently synchronize with the main [eclipse-pass
 
 This can be done with a tool like [SiteSucker](https://apps.apple.com/us/app/sitesucker/id442168834) on a Mac.
 
-![Download site with SiteSucker](/docs/assets/eclipsesync/sitesucker.png)
+![Download site with SiteSucker](../assets/eclipsesync/sitesucker.png)
 
 2. Update the [eclipse-pass.github.io](https://github.com/eclipse-pass/eclipse-pass.github.io) repo.
 
@@ -59,7 +59,7 @@ Should be updated to
 
 Once the code is in main, the site will automatically be deployed to [eclipse-pass.org](https://eclipse-pass.org).
 
-![Updates deployed on merge](/docs/assets/eclipsesync/github_pages_actions_deploy.png)
+![Updates deployed on merge](../assets/eclipsesync/github_pages_actions_deploy.png)
 
 
 ### demo.eclipse-pass.org
@@ -76,15 +76,15 @@ including the [Deploy passdemo action](https://github.com/eclipse-pass/pass-dock
 
 To publish an update, access the actions page.
 
-![pass-docker actions](/docs/assets/demo/passdocker_actions.png)
+![pass-docker actions](../assets/demo/passdocker_actions.png)
 
 You can then [run the workflow](https://github.com/eclipse-pass/pass-docker/actions/workflows/deploy_passdemo.yml)
 
-![run workflow](/docs/assets/demo/run_workflow.png)
+![run workflow](../assets/demo/run_workflow.png)
 
 And watch the deploy.
 
-![deployed actions](/docs/assets/demo/deploy_actions.png)
+![deployed actions](../assets/demo/deploy_actions.png)
 
 #### Locally Run Via Docker Compose
 
@@ -101,7 +101,7 @@ cd pass-docker && \
 ```
 
 For more information debugging the deployment to our demo servers
-please refer to our [demo deploy documentation](/docs/infra/deploy_demo.md).
+please refer to our [demo deploy documentation](deploy_demo.md).
 
 ### nightly.eclipse-pass.org
 
@@ -130,7 +130,7 @@ cd pass-docker && \
 
 For more information debugging the deployment to our demo servers
 (such as [nightly.eclipse-pass.org](https://nightly.eclipse-pass.org))
-please refer to our [demo deploy documentation](/docs/infra/deploy_demo.md).
+please refer to our [demo deploy documentation](deploy_demo.md).
 
 
 ## Infrastructure
@@ -142,9 +142,9 @@ project
 Which will do the following
 
 * Install docker
-* Install [github self-hosted runners](/docs/infra/self_hosted_github_runners.md)
+* Install [github self-hosted runners](self_hosted_github_runners.md)
 * Intall [pass-docker](https://github.com/eclipse-pass/pass-docker)
-* Configure [pass docker for a GH runner](/docs/infra/self_hosted_github_runners.md)
+* Configure [pass docker for a GH runner](self_hosted_github_runners.md)
 
 To configure the self-hosted runner you will need the GITHUB token,
 replacing the `XXX` with the actual token value.

--- a/docs/infra/pipeline.md
+++ b/docs/infra/pipeline.md
@@ -13,7 +13,7 @@ As different environments (cd, nightly, dev, demo, pre-production, production) a
 introduced this documentation will be updated to reflect those differences (for
 example cd, nightly, dev, demo will all use a _fake_ nihms FTP server).
 
-The [docker containers should be migrated based on eclipse-pass dependencies](/docs/dev/integration-test-docker-dependencies.md).
+The [docker containers should be migrated based on eclipse-pass dependencies](../dev/integration-test-docker-dependencies.md).
 
 ### Application Reposibilities
 
@@ -23,7 +23,7 @@ The PASS application will be responsible for
 * Updating environment manifests (e.g a new container image to upgrade the deposit service)
 * Deoploying to a setup environment (based on the manifest)
 
-![Application pipeline actions](/docs/assets/pipeline/pipeline_app.png)
+![Application pipeline actions](../assets/pipeline/pipeline_app.png)
 
 Note that the `pass-app` currently refers to the [pass-docker repo](https://github.com/eclipse-pass/pass-docker).
 The recommendation is that `pass-docker` be renamed (and enhanced) to
@@ -46,7 +46,7 @@ The individual projects will be responsible for
 * Building project artefacts (e.g. Java JARs, Docker images, Golang binaries)
 * Notifying the application of the update
 
-![Project pipeline actions](/docs/assets/pipeline/pipeline_project.png)
+![Project pipeline actions](../assets/pipeline/pipeline_project.png)
 
 The artefacts will be stored in a consistent manner so the application
 can correct grab the appropriate versions when orchestrating a release.
@@ -126,7 +126,7 @@ The following projects will manage building their own containers.
 ## Component CI/CD Capabilities
 
 The table below will document the progression from source code commits to
-a production running application for the many [PASS components](/docs/dev#components).
+a production running application for the many [PASS components](../dev#components).
 
 | Project | Build | UTs |ITs | Deploy |
 | --- | --- | --- | --- | --- |
@@ -260,9 +260,9 @@ The following repositories have been forked from others
 
 ## References
 
-* [Deploying pass-docker via EC2](/docs/infra/ec2.md)
-* [Deploying pass-docker via Digital Ocean](/docs/infra/digitalocean.md)
-* [Deploying pass-docker via Eclipse Foundation (EF)](/docs/infra/eclipseops.md)
-* [Our attempt to use Komposer to migrate Docker Compose to k8s manifest](/docs/infra/docker-composer-to-k8s-manifest.md)
+* [Deploying pass-docker via EC2](ec2.md)
+* [Deploying pass-docker via Digital Ocean](digitalocean.md)
+* [Deploying pass-docker via Eclipse Foundation (EF)](eclipseops.md)
+* [Our attempt to use Komposer to migrate Docker Compose to k8s manifest](docker-composer-to-k8s-manifest.md)
 * [Travis configs for pass-ui](https://travis-ci.org/github/OA-PASS/pass-ember/jobs/770188235/config)
 * [Coveralls for pass-ui (pass-ember URL no longer valid)](https://coveralls.io/)

--- a/docs/infra/self_hosted_github_runners.md
+++ b/docs/infra/self_hosted_github_runners.md
@@ -9,7 +9,7 @@ This can be useful for
 To use self-hosted runners, you will need to be an administrator of the GitHub project.
 If you can access `/settings/actions/runners` then you have the right access permissions.
 
-![GitHub Settings Runners](/docs/assets/github/github_settings_runners.png)
+![GitHub Settings Runners](../assets/github/github_settings_runners.png)
 
 ## Create Self-Hosted Runner
 
@@ -20,7 +20,7 @@ URL below to your organization/project).
 https://github.com/eclipse-pass/pass-docker/settings/actions/runners/new
 ```
 
-![GitHub Setup Runner Code](/docs/assets/github/create_self_runner_code.png)
+![GitHub Setup Runner Code](../assets/github/create_self_runner_code.png)
 
 Please refer to the latest self-hosted action runner setup instructions directly
 from GitHub, what follows is a (slightly modified) copy of the
@@ -120,7 +120,7 @@ If everything is configured correctly, then you should see the runners (assumes 
 https://github.com/eclipse-pass/pass-docker/settings/actions/runners
 ```
 
-![Passdemo runner on GitHub.com](/docs/assets/github/passdemo_runner.png)
+![Passdemo runner on GitHub.com](../assets/github/passdemo_runner.png)
 
 
 ## View Runners via API


### PR DESCRIPTION
For supporting GH markdown and GH (web)pages

We can ensure the links work in GH with
https://github.com/eclipse-pass/main/tree/relative-links-everywhere

And we cannot fully test on eclipse-pass.org/main until it's deployed :-(