### PR TITLE
Initial automation for Java release for main POM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
+          cache: 'maven'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -56,6 +57,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
   # Run for manual trigger (workflow dispatch), since you'll have release and next dev versions specified
+  # All commits will have a -SNAPSHOT project version anyway, since the releases will be handled here
   release:
     needs: setup
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish a release to Maven Central
+name: "Publish: manual full release OR automatic snapshot"
 
 on:
   workflow_dispatch:
@@ -9,19 +9,21 @@ on:
       nextversion:
         description: 'Next dev version'
         required: true
+  push:
+    branches:
+      - 'main'
 
 env:
   RELEASE: ${{ inputs.releaseversion }}
   NEXT: ${{ inputs.nextversion }}
 
 jobs:
-  publish:
+  setup:
     runs-on: ubuntu-latest
-
+    outputs:
+      # Output project version from the POM to conditionally run dependent steps
+      project-version: ${{ steps.project_version.outputs.version }}
     steps:
-      # =============================================================================
-      # Setup
-      # =============================================================================
       - name: Checkout latest code
         uses: actions/checkout@v3
 
@@ -35,7 +37,34 @@ jobs:
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
-          
+      
+      - name: Get project version from POM
+        id: project_version
+        run: echo "VERSION=`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`" >> $GITHUB_OUTPUT
+
+  # Run only if project POM has version ending in "-SNAPSHOT"
+  snapshot:
+    needs: setup
+    if: github.event_name == 'push' && endsWith(needs.setup.outputs.project-version, '-SNAPSHOT')
+    runs-on: ubuntu-latest
+    steps:
+      # =============================================================================
+      # TODO: Refactor to be reusable action
+      # :: shared among ALL publishing workflows
+      # =============================================================================
+      - name: Publish SNAPSHOT
+        run: mvn -B --no-transfer-progress clean deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+  # Run for manual trigger (workflow dispatch), since you'll have release and next dev versions specified
+  release:
+    needs: setup
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
       # =============================================================================
       # Start the release
       # =============================================================================
@@ -48,5 +77,14 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
+      - name: Build and publish new dev version
+        run: mvn -B -U -V -ntp deploy -P release
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
       - name: Push new release tag GH
-        run: git push origin --tags
+        run: |
+          git push 
+          git push origin --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,6 @@ on:
     branches:
       - 'main'
 
-env:
-  RELEASE: ${{ inputs.releaseversion }}
-  NEXT: ${{ inputs.nextversion }}
-
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -64,6 +60,9 @@ jobs:
     needs: setup
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    env:
+      RELEASE: ${{ inputs.releaseversion }}
+      NEXT: ${{ inputs.nextversion }}
     steps:
       # =============================================================================
       # Start the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Publish a release to Maven Central
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseversion:
+        description: 'Release version'
+        required: true
+      nextversion:
+        description: 'Next dev version'
+        required: true
+
+env:
+  RELEASE: ${{ inputs.releaseversion }}
+  NEXT: ${{ inputs.nextversion }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      # =============================================================================
+      # Setup
+      # =============================================================================
+      - name: Checkout latest code
+        uses: actions/checkout@v3
+
+      - name: Setup Java & Maven
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          
+      # =============================================================================
+      # Start the release
+      # =============================================================================
+      - name: Release main POM
+        run: |
+          mvn -B -U -V -ntp release:prepare -DreleaseVersion=$RELEASE -Dtag=$RELEASE -DdevelopmentVersion=$NEXT -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+          mvn -B -U -V -ntp release:perform -P release -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Push new release tag GH
+        run: git push origin --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,9 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
+      - name: Push release plugin commits
+        if: github.ref_type == 'branch' && github.ref_protected == false
+        run: git push origin ${{ github.ref_name }}
+
       - name: Push new release tag GH
-        run: |
-          git push 
-          git push origin --tags
+        run: git push origin --tags


### PR DESCRIPTION
Part of https://github.com/eclipse-pass/main/issues/462

Release automation(s) for the main POM

New workflow is intended to handle both SNAPSHOT and full releases:

* On push to `main` branch, it is intended that only the snapshot workflow executes (making sure to run only against a POM project version with `-SNAPSHOT` suffix)
* On manual workflow execution, the full release workflow is intended to run, since that is the only place we can specify full release version and next development version numbers

### TODO:
I'll need to add appropriate secrets to this repo before merging (which may run the SNAPSHOT workflow)