### PR TITLE
Add setup stuff to each job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,6 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           cache: 'maven'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       
       - name: Get project version from POM
         id: project_version
@@ -45,10 +40,21 @@ jobs:
     if: github.event_name == 'push' && endsWith(needs.setup.outputs.project-version, '-SNAPSHOT')
     runs-on: ubuntu-latest
     steps:
-      # =============================================================================
-      # TODO: Refactor to be reusable action
-      # :: shared among ALL publishing workflows
-      # =============================================================================
+      - name: Checkout latest code
+        uses: actions/checkout@v3
+
+      - name: Setup Java & Maven
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
       - name: Publish SNAPSHOT
         run: mvn -B --no-transfer-progress clean deploy
         env:
@@ -66,6 +72,20 @@ jobs:
       RELEASE: ${{ inputs.releaseversion }}
       NEXT: ${{ inputs.nextversion }}
     steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v3
+
+      - name: Setup Java & Maven
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       # =============================================================================
       # Start the release
       # =============================================================================


### PR DESCRIPTION
I made a bad assumption when attempting to use the initial "Setup" job to setup Java and Maven for the subsequent release/snapshot jobs. The project version output worked as expected and was successfully used to trigger the snapshot job and appropriately skip the release job. However, since each of these jobs runs on distinct (GH hosted) runners, Java and Maven need to be setup for each job. Future updates should refactor this setup into a reusable action that can be called in each job to have a "one-line" setup that can pull in the correct secrets and other prep tasks.

_[Failed run](https://github.com/eclipse-pass/main/actions/runs/4285432490/jobs/7463731546)_: The error message likely resulted because the code wasn't checked out prior to invoking Maven for the reasons given above.

For this update, I just copied the setup actions into each job where they were needed