### PR TITLE
High level release notes 

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Release v0.1.0
+This is the initial release of the Eclipse PASS codebase. The following changes were made to the code after completing the transition to Eclipse:
+
+Naming changes - updating code to transition to the Eclipse PASS name
+Version alignment - ensuring all project components utilize a consistent versioning scheme
+Data model alignment - ensuring all project components utilize the same version of the data model
+Adjustments to release process - updates to allow release of Java components to Maven Central with a new groupId
+Introduction of code style guide - ensuring code conforms to consistent guidelines
+Adjustments to testing methods - transitioning to the use of GitHub Actions for the execution of unit and integration testing
+Initial documentation - providing a starting point for development and deployment documentation
+
 ## Release v0.2.0
 Release 0.2.0 provides a major upgrade to the backend architecture of the PASS application. 
 The Fedora Repository has been replaced with a completely new REST API built using Elide and backed by 
@@ -19,4 +30,9 @@ Some major changes for v0.2.0 are
 either been implemented in Java or eliminated
 * Refactoring of authorization functionality in javascript closer to the UI
 
+## Release v0.3.0
 
+This release introduces a new file handling service for dealing with file uploads in PASS. Releases are now largely automated using GitHub workflows.
+
+* Release automations using GitHub workflows. Snapshot versions are published automatically and releases can be triggered manually in the GitHub UI
+* Add file API to pass-core for handling file related create, read, and delete operations


### PR DESCRIPTION
* Add brief notes for `0.3.0`
* Add notes for `0.1.0` pulled from the GH release of `main` (https://github.com/eclipse-pass/main/releases/tag/0.1.0)

## Preview
https://github.com/eclipse-pass/main/blob/232e1b95d214c1474e4a35b4ac950b820ab65add/docs/dev/CHANGELOG.md