### PR TITLE
Add a note about community message for releases

### DIFF
--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -67,6 +67,9 @@ Developers will need a GitHub account which is a member of the [eclipse-pass](ht
 * Update images in pass-docker
 * Test the release
 * Publish release notes
+* Post a message about the release to the [PASS Google Group](https://groups.google.com/g/pass-general)
+  * Release manager will draft the message, allowing the technical lead to provide feedback before posting
+  * Message should include at least: an overview of the high level changes in the release, plans for the next release, and a link to the changelog for the release
 
 A new release for each relevant project should be created in the GitHub user interface until automation is put in place.
 


### PR DESCRIPTION
Preview: https://github.com/eclipse-pass/main/blob/13f0eb9ce949c258d6e5bb32d541ba79f8e6c21c/docs/dev/release.md#process

We should include a message to the community for each release, via the PASS Google Group. I've included a note about this in the release documentation with this PR, with a draft of the high level process. 