### PR TITLE
Allow repo commit ref input to deploy workflow

### DIFF
--- a/.github/workflows/deployToAWS.yml
+++ b/.github/workflows/deployToAWS.yml
@@ -1,11 +1,33 @@
 name: "Publish to SNS Topic: Triggers Deployment to AWS"
 
 on:
+  workflow_call:
+    inputs:
+      DEPLOYMENT_ENVIRONMENT:
+        description: 'Environment'
+        type: string
+        required: true
+      targetCommitRef:
+        description: 'Commit ref to deploy'
+        type: string
+        default: 'main'
+    secrets:
+      AWS_REGION:
+        required: true
+      AWS_TOPIC_ARN:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
   workflow_dispatch:
     inputs:
       DEPLOYMENT_ENVIRONMENT:
         description: 'Environment'
         required: true
+      targetCommitRef:
+        description: 'Commit ref to deploy'
+        default: 'main'
 
 jobs:
   setup:
@@ -29,4 +51,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           DEPLOYMENT_ENVIRONMENT: ${{ inputs.DEPLOYMENT_ENVIRONMENT }}
+          TARGET_COMMIT_REF: ${{ inputs.targetCommitRef }}
         run: python tools/aws_sns_publish_topic.py

--- a/tools/aws_sns_publish_topic.py
+++ b/tools/aws_sns_publish_topic.py
@@ -7,8 +7,9 @@ SECRET_KEY = os.getenv('AWS_SECRET_ACCESS_KEY')
 TOPIC_ARN = os.getenv('AWS_TOPIC_ARN')
 DEPLOYMENT_ENVIRONMENT = os.getenv('DEPLOYMENT_ENVIRONMENT')
 REGION=os.getenv('AWS_REGION')
+COMMIT_REF = os.getenv('TARGET_COMMIT_REF')
 
-MESSAGE = {"action": "DeployStart", "commitRef": "main", "deployEnv": DEPLOYMENT_ENVIRONMENT}
+MESSAGE = {"action": "DeployStart", "commitRef": COMMIT_REF, "deployEnv": DEPLOYMENT_ENVIRONMENT}
 
 client = boto3.client('sns',
     region_name=REGION,


### PR DESCRIPTION
* Allow other workflows to call the deploy workflow, including workflows from other repos
* Deploy python script should pick up GH commit ref from env var, making it easier to deploy arbitrary points in git history, such as release tags

**Note: I believe external workflows that call the deploy workflow will also need the various AWS secrets in place, then pass them to the deploy workflow**

Example:
``` yml
jobs:
  deploy:
    uses: eclipse-pass/main/.github/workflows/deployToAws.yml@main
    # We can enumerate each necessary secret here, or 'inherit'
    secrets: inherit # Pass current workflows secrets to the "deployToAws" workflow
    with:
      DEPLOYMENT_ENVIRONMENT: 'demo'
      targetCommitRef: '0.7.0' # Example tag
```

Example using matrix strategy:
``` yml
jobs:
  deploy:
    strategy:
      matrix:
        target: [ demo, dev ]
    uses: eclipse-pass/main/.github/workflows/deployToAws.yml@main
    secrets: inherit
    with:
      DEPLOYMENT_ENVIRONMENT: ${{ matrix.target }}
      targetCommitRef: '0.7.0' # Example tag
```