### PR TITLE
Update release actions and notes for 1.2.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,19 @@
+## Release v1.2.0
+### Date: November 30, 2023
+
+This release focused on increasing the security of PASS and making interactions with external services more robust, notably the interface with NIHMS. Parameterized queries were added to the grant loader to enhance security. We've made substantial upgrades to the NIHMS data transfer within our Deposit Services and enhancements to the NIHMS loader. Updates were made to the data model documentation. A new JHU logo has been introduced and client-side pagination support has been added in the UI.
+
+Tickets Completed: https://github.com/eclipse-pass/main/milestone/16?closed=1
+
+Release Components:
+* main - https://github.com/eclipse-pass/main/releases/tag/1.2.0
+* pass-core - https://github.com/eclipse-pass/pass-core/releases/tag/1.2.0
+* pass-docker - https://github.com/eclipse-pass/pass-docker/releases/tag/1.2.0
+* pass-acceptance-testing - https://github.com/eclipse-pass/pass-acceptance-testing/releases/tag/1.2.0
+* pass-support - https://github.com/eclipse-pass/pass-support/releases/tag/1.2.0
+* pass-auth - https://github.com/eclipse-pass/pass-auth/releases/tag/1.2.0
+* pass-ui - https://github.com/eclipse-pass/pass-ui/releases/tag/1.2.0
+
 ## Release v1.1.0
 ### Date: October 26, 2023
 
@@ -12,7 +28,6 @@ Release Components:
 * pass-acceptance-testing - https://github.com/eclipse-pass/pass-acceptance-testing/releases/tag/1.1.0
 * pass-support - https://github.com/eclipse-pass/pass-support/releases/tag/1.1.0
 * pass-auth - https://github.com/eclipse-pass/pass-auth/releases/tag/1.1.0
-* pass-ui-public - https://github.com/eclipse-pass/pass-ui-public/releases/tag/1.1.0
 * pass-ui - https://github.com/eclipse-pass/pass-ui/releases/tag/1.1.0
 
 ## Release v1.0.0
@@ -29,7 +44,6 @@ Release Components:
 * pass-acceptance-testing - https://github.com/eclipse-pass/pass-acceptance-testing/releases/tag/1.0.0
 * pass-support - https://github.com/eclipse-pass/pass-support/releases/tag/1.0.0
 * pass-auth - https://github.com/eclipse-pass/pass-auth/releases/tag/1.0.0
-* pass-ui-public - https://github.com/eclipse-pass/pass-ui-public/releases/tag/1.0.0
 * pass-ui - https://github.com/eclipse-pass/pass-ui/releases/tag/1.0.0
 
 ## Release v0.9.0
@@ -46,7 +60,6 @@ Release Components:
 * pass-acceptance-testing - https://github.com/eclipse-pass/pass-acceptance-testing/releases/tag/0.9.0
 * pass-support - https://github.com/eclipse-pass/pass-support/releases/tag/0.9.0
 * pass-auth - https://github.com/eclipse-pass/pass-auth/releases/tag/0.9.0
-* pass-ui-public - https://github.com/eclipse-pass/pass-ui-public/releases/tag/0.9.0
 * pass-ui - https://github.com/eclipse-pass/pass-ui/releases/tag/0.9.0
 
 ## Release v0.8.0
@@ -63,7 +76,6 @@ Release Components:
 * pass-acceptance-testing - https://github.com/eclipse-pass/pass-acceptance-testing/releases/tag/0.8.0
 * pass-support - https://github.com/eclipse-pass/pass-support/releases/tag/0.8.0
 * pass-auth - https://github.com/eclipse-pass/pass-auth/releases/tag/0.8.0
-* pass-ui-public - https://github.com/eclipse-pass/pass-ui-public/releases/tag/0.8.0
 * pass-ui - https://github.com/eclipse-pass/pass-ui/releases/tag/0.8.0
 
 ## Release v0.7.0
@@ -80,7 +92,6 @@ Release Components:
 * pass-acceptance-testing - https://github.com/eclipse-pass/pass-acceptance-testing/releases/tag/0.7.0
 * pass-support - https://github.com/eclipse-pass/pass-support/releases/tag/0.7.0
 * pass-auth - https://github.com/eclipse-pass/pass-auth/releases/tag/0.7.0
-* pass-ui-public - https://github.com/eclipse-pass/pass-ui-public/releases/tag/0.7.0
 * pass-ui - https://github.com/eclipse-pass/pass-ui/releases/tag/0.7.0
 
 ## Release v0.6.0

--- a/docs/release/release-actions-1.2.0.md
+++ b/docs/release/release-actions-1.2.0.md
@@ -1,0 +1,71 @@
+# Release Manager Actions Checklist Template
+
+|  |                |
+| --- |----------------|
+| Release version | 1.2.0          |
+| Next dev version | 1.3.0-SNAPSHOT |
+
+## Release Process Overview
+This is the full detailed release process, including the steps that are performed by the GitHub automation: [Release](../dev/release.md)
+
+## Pre-release
+
+- [X] Identify the version to be utilized for the release.
+- [X] Ensure all code commits and PRs intended for the release have been merged.
+- [X] Issue a code freeze statement on the Eclipse PASS slack #pass-dev channel to notify all developers that a release is imminent.
+
+## Release Java Projects
+[Release Steps with Automations](../dev/release-steps-with-automations.md)
+
+Release Workflow Example: [Triggering a GitHub workflow](../dev/release-steps-with-automations.md#triggering-a-gitHub-workflow)
+
+- [X] Release Main - [Main Release workflow](https://github.com/eclipse-pass/main/actions/workflows/release.yml)
+- [X] Verify Main Artifacts on Maven Central - [Main Artifacts on Maven Central](https://central.sonatype.com/artifact/org.eclipse.pass/eclipse-pass-parent)
+- [X] Main GitHub Release Page - Perform after the Main release is complete - [Main GitHub Release Page](https://github.com/eclipse-pass/main/releases)
+
+ ---
+
+- [X] Release Pass-Core - [Pass-Core Release workflow](https://github.com/eclipse-pass/pass-core/actions/workflows/release.yml)
+- [X] Verify Pass-Core Artifacts on Maven Central - [Pass-Core Artifacts on Maven Central](https://central.sonatype.com/artifact/org.eclipse.pass/pass-core)
+- [X] Pass-Core GitHub Release Page - Perform after the Pass Core release is complete - [Pass Core GitHub Release Page](https://github.com/eclipse-pass/pass-core/releases)
+
+ ---
+ 
+- [X] Release Pass Support - [Pass Support Release workflow](https://github.com/eclipse-pass/pass-support/actions/workflows/release.yml)
+- [X] Verify Pass Support Artifacts on Maven Central - [Pass Support Artifacts on Maven Central](https://central.sonatype.com/artifact/org.eclipse.pass/pass-support)
+- [X] Pass Support GitHub Release Page - Perform after the Pass Support release is complete - [Pass Support GitHub Release Page](https://github.com/eclipse-pass/pass-support/releases)
+
+## Release Non-Java Projects
+
+- [X] Release Pass UI - [Pass UI workflow](https://github.com/eclipse-pass/pass-ui/actions/workflows/release.yml)
+- [X] Verify Pass UI packages [Pass UI Packages](https://github.com/eclipse-pass/pass-ui/pkgs/container/pass-ui)
+- [X] Pass UI Release Page - Perform after the Pass UI release is complete - [Pass UI GitHub Release Page](https://github.com/eclipse-pass/pass-ui/releases)
+
+ ---
+ 
+- [X] Release Pass Auth - [Pass Auth workflow](https://github.com/eclipse-pass/pass-auth/actions/workflows/release.yml)
+- [X] Verify Pass Auth packages [Pass Auth Packages](https://github.com/eclipse-pass/pass-auth/pkgs/container/pass-auth)
+- [X] Pass Auth Release Page - Perform after the Pass Auth release is complete - [Pass Auth GitHub Release Page](https://github.com/eclipse-pass/pass-auth/releases)
+
+ ---
+ 
+- [X] Release Pass Acceptance Testing - [Pass Acceptance Testing workflow](https://github.com/eclipse-pass/pass-acceptance-testing/actions/workflows/release.yml)
+- [X] Verify Pass Acceptance Testing Tag [Pass Acceptance Testing Tag](https://github.com/eclipse-pass/pass-acceptance-testing/tags)
+- [X] Pass Acceptance Testing Release Page - Perform after the Pass Acceptance Testing release is complete - [Pass Acceptance Testing GitHub Release Page](https://github.com/eclipse-pass/pass-acceptance-testing/releases)
+
+## Release Other Projects
+Note: This must be released last because it relies on some Docker images that will be published during the release process.
+
+- [X] Release Pass Docker - Select checkbox for acceptance tests - [Release workflow](https://github.com/eclipse-pass/pass-docker/actions/workflows/release.yml)
+- [X] Pass Docker Release Page - Perform after the Pass Docker release is complete - [Pass Docker GitHub Release Page](https://github.com/eclipse-pass/pass-docker/releases)
+
+## Post-release
+
+- [X] Test the release by using the newly updated pass-docker to run the release locally.
+- [X] Check that correct tickets are in the release milestone. [Github Ticket Update](../dev/release.md#update-release-notes)
+- [X] Write release notes in the [Release Notes doc](../release-notes.md), update the [Roadmap](../roadmap.md), submit a PR for the changes, and ensure the PR is merged. Release Notes should be written to be understandable by community members who are not technical.
+- [X] Draft release message and have technical & community lead provide feedback. Ensure that a link to the release notes is included in the release message.
+- [X] Post a message about the release to the PASS Google Group.  [Notes about the PASS Google Group](../dev/release.md#process)
+- [X] Update template if any steps were missed or if any new tasks were added. Also make note of these new steps in the release-actions-X.X.X.md file.
+- [X] Update [Pass Demo](https://demo.eclipse-pass.org) to new release - [Publish to SNS Topic action](https://github.com/eclipse-pass/main/actions/workflows/deployToAWS.yml) using `Environment: demo`
+- [X] Send message to Eclipse PASS slack #pass-dev channel that the release is complete.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,15 +6,11 @@ If you are interested in helping to define and/or contribute to this roadmap, pl
 
 # [Completed Releases](release-notes.md)
 
-## 1.2.0
-This release will focus on updating integrations with external services and ensuring that those operating and maintaining the PASS application have the information needed to understand system activity
-* Update the NIH Manuscript Submission client to the latest specification
-* Update the grant loader to support Fibi, the new grant database at JHU
-* Address technical debt and improve documentation in order to prepare for potential partners
-* Improve logging configuration to ensure logging is captured and utilized consistently across the project
-* Define, capture, and expose metrics required for understanding performance, system utilization, and discovering errors
-
 ## 1.3.0
-This release will focus on deposit system integrations and preparation for an upcoming administrative console
-* Integrating top priority repository systems to support additional deposit endpoints
-* API additions that will be used to support an administrative user interface
+This release will focus enhancing the NIHMS interface and security. There will be maintenance to address technical debt and bug fixes.
+
+* Design and implementation of NIHMS error handling of deposits
+* Add funder and grant information on NIHMS deposits
+* Address and remediate security vulnerabilities
+* Investigate simplifying pass-proxy and pass-auth and merging into pass-core
+* Various bug fixes and IT/Acceptance Test improvements


### PR DESCRIPTION
All 1.2.0 releases are done and can be found on their respective release pages. Ran pass-docker 1.2.0 locally and could step through the workflow as several types of users. 

Once this PR is merged the final outstanding steps to do are:

- Publish message on our Google groups
- Send message to #pass-dev

Note: Removed pass-ui-public from the release components. No longer released since 0.6.0