### PR TITLE
Add template for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/standard-issue.md
+++ b/.github/ISSUE_TEMPLATE/standard-issue.md
@@ -1,0 +1,32 @@
+---
+name: Standard Issue
+about: Standard information for PASS issues
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Please answer the following questions for yourself before submitting an issue. 
+**YOU SHOULD DELETE THE PREREQUISITES SECTION.**
+
+# Prerequisites
+
+- [ ] Is the title clear and understandable at a glance?
+- [ ] Is a label present?
+
+# What? 
+
+Can be written as a user story (“As a user, I want to, so that I can…) or a simple goal/purpose.
+
+# Why?
+
+Why we are doing this work (the value this gives to the user - whether an end-user, the development team, other institutions, etc.)
+
+# How?
+
+Implementation details
+
+# Acceptance Criteria 
+
+The issue is done when these things are accomplished. This is only added if applicable, as sometime the issue itself - especially purely technical issues - are the acceptance criteria.

--- a/.github/ISSUE_TEMPLATE/standard-issue.md
+++ b/.github/ISSUE_TEMPLATE/standard-issue.md
@@ -29,4 +29,4 @@ Implementation details - If you have an approach in mind, list it here. This is 
 
 # Acceptance Criteria 
 
-The issue is done when these things are accomplished. This is only added if applicable, as sometime the issue itself - especially purely technical issues - are the acceptance criteria.
+What must be true for this work to be considered complete and correct? Include if applicable.

--- a/.github/ISSUE_TEMPLATE/standard-issue.md
+++ b/.github/ISSUE_TEMPLATE/standard-issue.md
@@ -7,13 +7,15 @@ assignees: ''
 
 ---
 
-Please answer the following questions for yourself before submitting an issue. 
-**YOU SHOULD DELETE THE PREREQUISITES SECTION.**
-
 # Prerequisites
 
-- [ ] Is the title clear and understandable at a glance?
-- [ ] Is a label present?
+Please answer the following questions for yourself before submitting an issue:
+  * Is the title clear and understandable at a glance?
+  * Is a label present if appropriate?
+
+Labels are not required for all tickets, but they are helpful for prioritization. Please check the labels drop-down to see if any of the pre-set labels work for your ticket.
+
+**YOU SHOULD DELETE THE PREREQUISITES SECTION.**
 
 # What? 
 
@@ -30,3 +32,9 @@ Implementation details - If you have an approach in mind, list it here. This is 
 # Acceptance Criteria 
 
 What must be true for this work to be considered complete and correct? Include if applicable.
+
+# Related Issues
+
+  * #123 is related because of xyz.
+
+List related issues here.

--- a/.github/ISSUE_TEMPLATE/standard-issue.md
+++ b/.github/ISSUE_TEMPLATE/standard-issue.md
@@ -17,7 +17,7 @@ Please answer the following questions for yourself before submitting an issue.
 
 # What? 
 
-Can be written as a user story (“As a user, I want to, so that I can…) or a simple goal/purpose.
+Can be written as a user story (“As a user, I want to, so that I can…") or a simple goal/purpose.
 
 # Why?
 

--- a/.github/ISSUE_TEMPLATE/standard-issue.md
+++ b/.github/ISSUE_TEMPLATE/standard-issue.md
@@ -25,7 +25,7 @@ Why we are doing this work (the value this gives to the user - whether an end-us
 
 # How?
 
-Implementation details
+Implementation details - If you have an approach in mind, list it here. This is optional.
 
 # Acceptance Criteria 
 

--- a/.github/ISSUE_TEMPLATE/standard-issue.md
+++ b/.github/ISSUE_TEMPLATE/standard-issue.md
@@ -21,7 +21,7 @@ Can be written as a user story (“As a user, I want to, so that I can…") or a
 
 # Why?
 
-Why we are doing this work (the value this gives to the user - whether an end-user, the development team, other institutions, etc.)
+Why should this work be done (the value this provides to end users or other project participants)
 
 # How?
 


### PR DESCRIPTION
Create a template to provide standard information about issues.

The template cannot be tested in this repository until it is merged into main. But I've added it to another repository so it can be tested. See https://github.com/markpatton/dcs/issues.

Note that the formatting has been slightly altered from when it was first shown off.