### PR TITLE
Move acceptance-test action to main

### DIFF
--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -1,0 +1,64 @@
+name: PASS acceptance tests
+description: Run pass-acceptance-tests
+
+# TODO: Would be nice to allow replacement images
+
+inputs:
+  timeouts:
+    description: 'Testing timeouts (ms)'
+    default: '60000'
+
+runs:
+  using: composite
+  steps:
+    - run: |
+        echo "Set timeouts: ${{ inputs.timeouts }}"
+      shell: bash
+
+    - name: Append hosts file to enable "pass.local" on localhost
+      shell: bash
+      run: echo "127.0.0.1    pass.local" | sudo tee -a /etc/hosts
+
+    - name: Checkout pass-docker
+      uses: actions/checkout@v3
+      with:
+        repository: eclipse-pass/pass-docker
+        path: pass-docker
+
+    - name: Checkout pass-acceptance-testing
+      uses: actions/checkout@v3
+      with:
+        repository: eclipse-pass/pass-acceptance-testing
+        path: pass-acceptance-testing
+
+    - name: Run pass-docker
+      shell: bash
+      working-directory: pass-docker
+      run: docker compose -f docker-compose.yml -f eclipse-pass.local.yml up -d --no-build --quiet-pull
+    
+    # Show both views to see which images are in use by docker compose but with extra info like time created from docker
+    - name: Print Docker images
+      shell: bash
+      working-directory: pass-docker
+      run: |
+        docker images
+        docker compose images
+
+    - name: Run acceptance tests
+      shell: bash
+      working-directory: pass-acceptance-testing
+      run: |
+        yarn install --frozen-lockfile
+        npx testcafe \
+          'chrome:headless --ignore-certificate-errors --allow-insecure-localhost' \
+          --hostname localhost \
+          tests/*Tests.js \
+          --selector-timeout ${{ inputs.timeouts}} \
+          --assertion-timeout ${{ inputs.timeouts}} \
+          --ajax-request-timeout ${{ inputs.timeouts}}
+
+    - name: Stop pass-docker
+      if: always()
+      shell: bash
+      working-directory: pass-docker
+      run: docker compose -f docker-compose.yml -f eclipse-pass.local.yml down -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Run Tests
         run: mvn -U -B -V -ntp verify
 
-      - name: Acceptance tests
-        if: ${{ inputs.run_acceptance_tests }}
-        uses: .github/actions/acceptance-test@main
-        with:
-          pullimages: missing
+      # - name: Acceptance tests
+      #   if: ${{ inputs.run_acceptance_tests }}
+      #   uses: eclipse-pass/main/.github/actions/acceptance-test@main
+      #   with:
+      #     pullimages: missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,19 @@
 name: main Continuous Integration
-on: [pull_request, workflow_dispatch, workflow_call]
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      run_acceptance_tests:
+        description: Should acceptance tests be run?
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      run_acceptance_tests:
+        description: Should acceptance tests be run?
+        type: boolean
+        default: true
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}
@@ -27,3 +41,9 @@ jobs:
 
       - name: Run Tests
         run: mvn -U -B -V -ntp verify
+
+      - name: Acceptance tests
+        if: ${{ inputs.run_acceptance_tests }}
+        uses: .github/actions/acceptance-test@main
+        with:
+          pullimages: missing


### PR DESCRIPTION
Move the acceptance tests GH action into main to have all the shared GH related actions/workflows consolidated. We can migrate `pass-acceptance-testing` test action to use this as well after this is merged

- Will need to update the `ci.yml` workflow to run this action after this is merged. If added here, GitHub will not be able to find the action and spike it
- Make the acceptance tests optional because currently changes to pass-support have no coverage with these tests (will require an update to pass-support workflow to opt-out of the tests)