### PR TITLE
Turn on acceptance testing for java ci workflow by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Run Tests
         run: mvn -U -B -V -ntp verify
 
-      # - name: Acceptance tests
-      #   if: ${{ inputs.run_acceptance_tests }}
-      #   uses: eclipse-pass/main/.github/actions/acceptance-test@main
-      #   with:
-      #     pullimages: missing
+      - name: Acceptance tests
+        if: ${{ inputs.run_acceptance_tests }}
+        uses: eclipse-pass/main/.github/actions/acceptance-test@main
+        with:
+          pullimages: missing


### PR DESCRIPTION
Related https://github.com/eclipse-pass/main/issues/605

Acceptance tests can be disabled in repos by calling this workflow with `run_acceptance_tests: false`. Should be done for pass-support, at least

(This workflow already has the input on `workflow_call` and `workflow_dispatch`)