### PR TITLE
Fix maven-release action check for sonatype error

### DIFF
--- a/.github/actions/maven-release/action.yml
+++ b/.github/actions/maven-release/action.yml
@@ -30,7 +30,7 @@ runs:
           goal="install"
         fi
 
-        mvn -B -U -V -ntp -P release -DstagingProgressTimeoutMinutes=15 clean $goal | tee release.log
+        mvn -B -U -V -ntp -P release -DstagingProgressTimeoutMinutes=15 clean $goal 2>&1 | tee release.log
         code=${PIPESTATUS[0]}
 
         marker1="Remote staging repositories are being released"


### PR DESCRIPTION
In the last release the check for Sonatype reporting an error, but actually being successful did not work.

The check works by looking for two markers in the maven output which is written to a file by tee. It may have been the case that one of the markers was written to stderr which was not captured by tee. This pr redirects the maven stderr to stdout so that tee will capture it. Hopefully this will fix the check.