### PR TITLE
Update release actions and notes for Release 1.5.0

### DIFF
--- a/docs/dev/release-steps-with-automations.md
+++ b/docs/dev/release-steps-with-automations.md
@@ -15,7 +15,7 @@ gh auth login
 gh secret set JAVA_RELEASE_PAT --body <PAT_VALUE> --repo eclipse-pass/main
 ```
 
-If needed, the individual java components can be release individually.Release these in the order defined here due to 
+If needed, the individual java components can be released individually. Release these in the order defined here due to 
 dependencies. Between each of these releases, you will need to wait for the Java artifacts to appear on Maven Central. 
 This will give you enough time to do other release activities, such as releasing non-Java artifacts. The release 
 workflows should wait for you, but is good to check anyway.

--- a/docs/dev/release-steps-with-automations.md
+++ b/docs/dev/release-steps-with-automations.md
@@ -3,8 +3,22 @@
 Actions listed below are to be done by the release manager.
 
 ### Java projects
+The [combined Java workflow](https://github.com/eclipse-pass/main/actions/workflows/pass-java-release.yml) combines all the Java projects together and then releases them in one single workflow.
+This workflow depends on the JAVA_RELEASE_PAT secret having permission to access all the eclipse-pass repositories and write packages.
+You have to create a new classic Personal Access Token (PAT) to do the release (GitHub/Settings/Developer Settings/Personal access tokens/Tokens (classic)).
+If you do so, set the expiration to 7 days, check the `repo` and the `write:packages` scope (subscopes under `repo`
+and `write:packages` will be selected too).
 
-You will need to release these in the order defined here due to dependencies. Between each of these releases, you will need to wait for the Java artifacts to appear on Maven Central. This will give you enough time to do other release activities, such as releasing non-Java artifacts. The release workflows should wait for you, but is good to check anyway.
+How to set the secret using the gh command line tool [GitHub CLI](https://cli.github.com/):
+```
+gh auth login
+gh secret set JAVA_RELEASE_PAT --body <PAT_VALUE> --repo eclipse-pass/main
+```
+
+If needed, the individual java components can be release individually.Release these in the order defined here due to 
+dependencies. Between each of these releases, you will need to wait for the Java artifacts to appear on Maven Central. 
+This will give you enough time to do other release activities, such as releasing non-Java artifacts. The release 
+workflows should wait for you, but is good to check anyway.
 
 1. [`main`](https://github.com/eclipse-pass/main)
    * [Release workflow](https://github.com/eclipse-pass/main/actions/workflows/release.yml)
@@ -22,17 +36,6 @@ You will need to release these in the order defined here due to dependencies. Be
    * https://github.com/orgs/eclipse-pass/packages/container/package/pass-journal-loader
    * https://github.com/orgs/eclipse-pass/packages/container/package/pass-nihms-loader
 
-You can instead use a [combined Java workflow](https://github.com/eclipse-pass/main/actions/workflows/pass-java-release.yml) which combines all the Java projects together and then releases them. 
-This workflow depends on the JAVA_RELEASE_PAT secret having permission to access all the eclipse-pass repositories and write packages. 
-You have to create a new classic Personal Access Token (PAT) to do the release (GitHub/Settings/Developer Settings/Personal access tokens/Tokens (classic)). 
-If you do so, set the expiration to 7 days, check the `repo` and the `write:packages` scope (subscopes under `repo` 
-and `write:packages` will be selected too).
-
-How to set the secret using the gh command line tool [GitHub CLI](https://cli.github.com/):
-```
-gh auth login
-gh secret set JAVA_RELEASE_PAT --body <PAT_VALUE> --repo eclipse-pass/main
-```
 
 ### Non-Java projects
 These can be released in any order. You should release these between releasing Java components, while waiting for artifacts to become available in Maven Central.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,26 @@
+## Release v1.5.0
+### Date: March 28, 2024
+
+Release Manager: Timothy Sanders, JHU
+
+This release focused on use cases for the planned Admin UI, documentation for the PASS Welcome Guide, 
+and enhancements to the grant and nihms data loaders. We added updated parameters to the nihms loader for scheduled 
+environments, and revised the nihms email processing. The grant loader had updates to its aggregation rules, CSV ingest, 
+and extended test coverage. We simplified our CI/CD pipeline by creating a single action to deploy all PASS components 
+to a specified environment. Began consolidating the authentication process to integrate Spring Security into pass-core, 
+enhancing flexibility and security.
+
+Tickets Completed: https://github.com/eclipse-pass/main/milestone/19?closed=1
+
+Release Components:
+* main - https://github.com/eclipse-pass/main/releases/tag/1.5.0
+* pass-core - https://github.com/eclipse-pass/pass-core/releases/tag/1.5.0
+* pass-docker - https://github.com/eclipse-pass/pass-docker/releases/tag/1.5.0
+* pass-acceptance-testing - https://github.com/eclipse-pass/pass-acceptance-testing/releases/tag/1.5.0
+* pass-support - https://github.com/eclipse-pass/pass-support/releases/tag/1.5.0
+* pass-auth - https://github.com/eclipse-pass/pass-auth/releases/tag/1.5.0
+* pass-ui - https://github.com/eclipse-pass/pass-ui/releases/tag/1.5.0
+
 ## Release v1.4.0
 ### Date: February 28, 2024
 

--- a/docs/release/release-actions-1.5.0.md
+++ b/docs/release/release-actions-1.5.0.md
@@ -21,41 +21,41 @@ This is the full detailed release process, including the steps that are performe
 [Release All Java Modules Workflow](https://github.com/eclipse-pass/main/actions/workflows/pass-java-release.yml)
 
 Java Modules:
-- [ ] Release Main
-- [ ] Release Pass-Core
-- [ ] Release Pass Support
+- [X] Release Main
+- [X] Release Pass-Core
+- [X] Release Pass Support
 
 
 ## Release Non-Java Projects
 
-- [ ] Release Pass UI - [Pass UI workflow](https://github.com/eclipse-pass/pass-ui/actions/workflows/release.yml)
-- [ ] Verify Pass UI packages [Pass UI Packages](https://github.com/eclipse-pass/pass-ui/pkgs/container/pass-ui)
-- [ ] Pass UI Release Page - Perform after the Pass UI release is complete - [Pass UI GitHub Release Page](https://github.com/eclipse-pass/pass-ui/releases)
+- [X] Release Pass UI - [Pass UI workflow](https://github.com/eclipse-pass/pass-ui/actions/workflows/release.yml)
+- [X] Verify Pass UI packages [Pass UI Packages](https://github.com/eclipse-pass/pass-ui/pkgs/container/pass-ui)
+- [X] Pass UI Release Page - Perform after the Pass UI release is complete - [Pass UI GitHub Release Page](https://github.com/eclipse-pass/pass-ui/releases)
 
  ---
  
-- [ ] Release Pass Auth - [Pass Auth workflow](https://github.com/eclipse-pass/pass-auth/actions/workflows/release.yml)
-- [ ] Verify Pass Auth packages [Pass Auth Packages](https://github.com/eclipse-pass/pass-auth/pkgs/container/pass-auth)
-- [ ] Pass Auth Release Page - Perform after the Pass Auth release is complete - [Pass Auth GitHub Release Page](https://github.com/eclipse-pass/pass-auth/releases)
+- [X] Release Pass Auth - [Pass Auth workflow](https://github.com/eclipse-pass/pass-auth/actions/workflows/release.yml)
+- [X] Verify Pass Auth packages [Pass Auth Packages](https://github.com/eclipse-pass/pass-auth/pkgs/container/pass-auth)
+- [X] Pass Auth Release Page - Perform after the Pass Auth release is complete - [Pass Auth GitHub Release Page](https://github.com/eclipse-pass/pass-auth/releases)
 
  ---
  
-- [ ] Release Pass Acceptance Testing - [Pass Acceptance Testing workflow](https://github.com/eclipse-pass/pass-acceptance-testing/actions/workflows/release.yml)
-- [ ] Verify Pass Acceptance Testing Tag [Pass Acceptance Testing Tag](https://github.com/eclipse-pass/pass-acceptance-testing/tags)
-- [ ] Pass Acceptance Testing Release Page - Perform after the Pass Acceptance Testing release is complete - [Pass Acceptance Testing GitHub Release Page](https://github.com/eclipse-pass/pass-acceptance-testing/releases)
+- [X] Release Pass Acceptance Testing - [Pass Acceptance Testing workflow](https://github.com/eclipse-pass/pass-acceptance-testing/actions/workflows/release.yml)
+- [X] Verify Pass Acceptance Testing Tag [Pass Acceptance Testing Tag](https://github.com/eclipse-pass/pass-acceptance-testing/tags)
+- [X] Pass Acceptance Testing Release Page - Perform after the Pass Acceptance Testing release is complete - [Pass Acceptance Testing GitHub Release Page](https://github.com/eclipse-pass/pass-acceptance-testing/releases)
 
 ## Release Other Projects
 Note: This must be released last because it relies on some Docker images that will be published during the release process.
 
-- [ ] Release Pass Docker - Select checkbox for acceptance tests - [Release workflow](https://github.com/eclipse-pass/pass-docker/actions/workflows/release.yml)
-- [ ] Verify Pass Docker Tag [Pass Docker Tag](https://github.com/eclipse-pass/pass-docker/tags)
-- [ ] Pass Docker Release Page - Perform after the Pass Docker release is complete - [Pass Docker GitHub Release Page](https://github.com/eclipse-pass/pass-docker/releases)
+- [X] Release Pass Docker - Select checkbox for acceptance tests - [Release workflow](https://github.com/eclipse-pass/pass-docker/actions/workflows/release.yml)
+- [X] Verify Pass Docker Tag [Pass Docker Tag](https://github.com/eclipse-pass/pass-docker/tags)
+- [X] Pass Docker Release Page - Perform after the Pass Docker release is complete - [Pass Docker GitHub Release Page](https://github.com/eclipse-pass/pass-docker/releases)
 
 ## Post-release
 
-- [ ] Test the release by using the newly updated pass-docker to run the release locally.
-- [ ] Check that correct tickets are in the release milestone. [Github Ticket Update](../dev/release.md#update-release-notes)
-- [ ] Write release notes in the [Release Notes doc](../release-notes.md), submit a PR for the changes, and ensure the PR is merged. Release Notes should be written to be understandable by community members who are not technical.
+- [X] Test the release by using the newly updated pass-docker to run the release locally.
+- [X] Check that correct tickets are in the release milestone. [Github Ticket Update](../dev/release.md#update-release-notes)
+- [X] Write release notes in the [Release Notes doc](../release-notes.md), submit a PR for the changes, and ensure the PR is merged. Release Notes should be written to be understandable by community members who are not technical.
 - [ ] Draft release message and have technical & community lead provide feedback. Ensure that a link to the release notes is included in the release message.
 - [ ] Post a message about the release to the PASS Google Group.  [Notes about the PASS Google Group](../dev/release.md#process)
 - [ ] Update template if any steps were missed or if any new tasks were added. Also make note of these new steps in the release-actions-X.X.X.md file.

--- a/docs/release/release-actions-1.5.0.md
+++ b/docs/release/release-actions-1.5.0.md
@@ -56,8 +56,8 @@ Note: This must be released last because it relies on some Docker images that wi
 - [X] Test the release by using the newly updated pass-docker to run the release locally.
 - [X] Check that correct tickets are in the release milestone. [Github Ticket Update](../dev/release.md#update-release-notes)
 - [X] Write release notes in the [Release Notes doc](../release-notes.md), submit a PR for the changes, and ensure the PR is merged. Release Notes should be written to be understandable by community members who are not technical.
-- [ ] Draft release message and have technical & community lead provide feedback. Ensure that a link to the release notes is included in the release message.
-- [ ] Post a message about the release to the PASS Google Group.  [Notes about the PASS Google Group](../dev/release.md#process)
-- [ ] Update template if any steps were missed or if any new tasks were added. Also make note of these new steps in the release-actions-X.X.X.md file.
-- [ ] Update [Pass Demo](https://demo.eclipse-pass.org) to new release - [Publish to SNS Topic action](https://github.com/eclipse-pass/main/actions/workflows/deployToAWS.yml) using `Environment: demo`
-- [ ] Send message to Eclipse PASS slack #pass-dev channel that the release is complete.
+- [X] Draft release message and have technical & community lead provide feedback. Ensure that a link to the release notes is included in the release message.
+- [X] Post a message about the release to the PASS Google Group.  [Notes about the PASS Google Group](../dev/release.md#process)
+- [X] Update template if any steps were missed or if any new tasks were added. Also make note of these new steps in the release-actions-X.X.X.md file.
+- [X] Update [Pass Demo](https://demo.eclipse-pass.org) to new release - [Publish to SNS Topic action](https://github.com/eclipse-pass/main/actions/workflows/deployToAWS.yml) using `Environment: demo`
+- [X] Send message to Eclipse PASS slack #pass-dev channel that the release is complete.

--- a/docs/release/release-actions-1.5.0.md
+++ b/docs/release/release-actions-1.5.0.md
@@ -10,9 +10,9 @@ This is the full detailed release process, including the steps that are performe
 
 ## Pre-release
 
-- [ ] Identify the version to be utilized for the release.
-- [ ] Ensure all code commits and PRs intended for the release have been merged.
-- [ ] Issue a code freeze statement on the Eclipse PASS slack #pass-dev channel to notify all developers that a release is imminent.
+- [X] Identify the version to be utilized for the release.
+- [X] Ensure all code commits and PRs intended for the release have been merged.
+- [X] Issue a code freeze statement on the Eclipse PASS slack #pass-dev channel to notify all developers that a release is imminent.
 
 
 ## Release Java Projects

--- a/docs/release/release-actions-1.5.0.md
+++ b/docs/release/release-actions-1.5.0.md
@@ -1,9 +1,9 @@
 # Release Manager Actions Checklist Template
 
-|  |  |
-| --- | --- |
-| Release version |  |
-| Next dev version |  |
+|  |              |
+| --- |--------------|
+| Release version | 1.5.0        |
+| Next dev version | 1.6.0-SNAPSHOT |
 
 ## Release Process Overview
 This is the full detailed release process, including the steps that are performed by the GitHub automation: [Release](../dev/release.md)


### PR DESCRIPTION
The following was changed:

- Added 1.5.0 checklist
- Updated release template
- Updated `release-steps-with-automations.md` to move `Combined Java Workflow` at the top of `Java Projects` and make the old process clear that it's only needed if components need to be released individually.
- Added v1.5.0 release notes