### PR TITLE
Complete Release Workflow

### DIFF
--- a/.github/actions/yarn-build/action.yml
+++ b/.github/actions/yarn-build/action.yml
@@ -1,0 +1,34 @@
+name: Build yarn module for release
+description: |
+  Build yarn module
+
+inputs:
+  repository_dir:
+    description: 'Directory of repository to build'
+    required: true
+  env_path:
+    description: 'Path to .env file'
+    required: true
+  is_dev:
+    description: 'Is dev build'
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Builds yarn module
+      shell: bash
+      working-directory: ${{ inputs.repository_dir }}
+      env:
+        ENV_FILE_PATH: ${{ inputs.env_path }}
+        IS_DEV: ${{ inputs.is_dev }}
+      run: |
+        export $(grep -v '^[#|SIGNING|PASS_CORE_POLICY]' $ENV_FILE_PATH | xargs -d '\n')
+        yarn install --frozen-lockfile
+        if [ "$IS_DEV" == "true" ]; then
+          yarn run build:dev
+        else
+          yarn run build
+        fi
+        yarn run build:docker

--- a/.github/actions/yarn-version/action.yml
+++ b/.github/actions/yarn-version/action.yml
@@ -6,15 +6,11 @@ inputs:
   repository_dir:
     description: 'Directory of repository to update'
     required: true
-  skip_tag:
-    description: 'Skip git tag'
-    required: false
-    default: "false"
 
 runs:
   using: composite
   steps:
-    - name: Update yarn version and tag ${{ env.RELEASE }}
+    - name: Update yarn version and tag
       shell: bash
       working-directory: ${{ inputs.repository_dir }}
       env:
@@ -24,7 +20,4 @@ runs:
         yarn config set version-git-tag false
         yarn version --new-version $RELEASE
         git commit --allow-empty -am "Update version to $RELEASE"
-        if [ "$SKIP_TAG" == "false" ]; then
-          echo "Tagging yarn version $RELEASE"
-          git tag $RELEASE
-        fi
+        git tag --force $RELEASE_TAG

--- a/.github/actions/yarn-version/action.yml
+++ b/.github/actions/yarn-version/action.yml
@@ -1,0 +1,30 @@
+name: Update yarn version for release
+description: |
+  Updates yarn version which automatically does a commit and this action tags
+
+inputs:
+  repository_dir:
+    description: 'Directory of repository to update'
+    required: true
+  skip_tag:
+    description: 'Skip git tag'
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Update yarn version and tag ${{ env.RELEASE }}
+      shell: bash
+      working-directory: ${{ inputs.repository_dir }}
+      env:
+        SKIP_TAG: ${{ inputs.skip_tag }}
+      run: |
+        yarn install --frozen-lockfile
+        yarn config set version-git-tag false
+        yarn version --new-version $RELEASE
+        git commit --allow-empty -am "Update version to $RELEASE"
+        if [ "$SKIP_TAG" == "false" ]; then
+          echo "Tagging yarn version $RELEASE"
+          git tag $RELEASE
+        fi

--- a/.github/workflows/pass-complete-release.yml
+++ b/.github/workflows/pass-complete-release.yml
@@ -1,4 +1,4 @@
-name: "(In development - Don't Use) Publish: Release All"
+name: "Publish: Release All"
 run-name: Release All Modules (${{ inputs.releaseversion }} -> ${{ inputs.nextversion}})
 
 on:
@@ -19,9 +19,10 @@ jobs:
       NEXT: ${{ inputs.nextversion }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: main
+          fetch-depth: 0
 
       - name: Setup Java & Maven
         uses: actions/setup-java@v3
@@ -35,17 +36,6 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Config git user
-        run: |
-          git config user.name ${{ github.actor }}
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-
-      - name: Setup Node & Yarn
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'yarn'
-
       - name: Get the artifact from the main POM
         working-directory: main
         run: |
@@ -56,7 +46,6 @@ jobs:
           git config --global user.name ${{ github.actor }}
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
-      # Combine modules together so maven can do everything at once for Java repos
       - name: Create combined module
         run: |
           mkdir combined
@@ -71,85 +60,234 @@ jobs:
           git clone https://${{ secrets.JAVA_RELEASE_PAT }}@github.com/eclipse-pass/pass-acceptance-testing.git combined/pass-acceptance-testing
           git clone https://${{ secrets.JAVA_RELEASE_PAT }}@github.com/eclipse-pass/pass-docker.git combined/pass-docker
 
-      - name: Set the release version, commit the change, and tag it
-        run: |
-          (cd main && mvn versions:set -B -ntp -DnewVersion=$RELEASE && git commit -am "Update version to $RELEASE" && git tag $RELEASE)
-          (cd combined && mvn versions:set -B -ntp -DnewVersion=$RELEASE)
-          (cd combined/pass-core && git commit -am "Update version to $RELEASE" && git tag $RELEASE)
-          (cd combined/pass-support && git commit -am "Update version to $RELEASE" && git tag $RELEASE)
-          (cd combined/pass-ui && yarn install --frozen-lockfile && yarn version --new-version $RELEASE && git commit -am "Update version to $RELEASE" && git tag $RELEASE)
-          (cd combined/pass-acceptance-testing && yarn install --frozen-lockfile && yarn version --new-version $RELEASE && git commit -am "Update version to $RELEASE" && git tag $RELEASE)
-          (cd combined/pass-docker && sed -i "/^PASS_VERSION/s/.*/PASS_VERSION=$RELEASE/" .env && git commit -am "Update version to $RELEASE" && git tag $RELEASE)
-
-#      - name: Release Java modules
-#        uses: ./main/.github/actions/maven-release
-#        with:
-#          repodir: combined
-#        env:
-#          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-#          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-#          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-
-      - name: Build pass-ui
-        uses: ./combined/pass-ui/.github/actions/build-pass-ui
+      - name: Setup Node & Yarn
+        uses: actions/setup-node@v3
         with:
-          is-prod: true
+          node-version: 18
 
-      - name: Build new pass-docker images
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.JAVA_RELEASE_PAT }}
+
+      - name: Check for Release tags
+        run: |
+          (cd main && echo "MAIN_TAG_EXISTS=$(git tag -l "$RELEASE")" >> $GITHUB_ENV)
+          (cd combined/pass-core && echo "PASS_CORE_TAG_EXISTS=$(git tag -l "$RELEASE")" >> $GITHUB_ENV)
+          (cd combined/pass-support && echo "PASS_SUPPORT_TAG_EXISTS=$(git tag -l "$RELEASE")" >> $GITHUB_ENV)
+          (cd combined/pass-ui && echo "PASS_UI_TAG_EXISTS=$(git tag -l "$RELEASE")" >> $GITHUB_ENV)
+          (cd combined/pass-acceptance-testing && echo "PASS_ACCPT_TEST_TAG_EXISTS=$(git tag -l "$RELEASE")" >> $GITHUB_ENV)
+          (cd combined/pass-docker && echo "PASS_DOCKER_TAG_EXISTS=$(git tag -l "$RELEASE")" >> $GITHUB_ENV)
+
+      - name: Create aggregate tag env vars
+        run: |
+          echo "ALL_JAVA_REPOS_TAG_EXISTS=${{ env.MAIN_TAG_EXISTS && env.PASS_CORE_TAG_EXISTS && env.PASS_SUPPORT_TAG_EXISTS }}" >> $GITHUB_ENV
+
+      # Note that the Java Repositories uses --force on tagging and pushing tagging.  This is to cover the case where
+      # there is a failure during the Push commits and tags step, then the workflow is re-run, we will update any tag
+      # that made it to the remote to the new commit created when updating the version.
+      - name: Set Release/commit/tag ~ Java Repositories
+        if: ${{ ! env.ALL_JAVA_REPOS_TAG_EXISTS }}
+        run: |
+          (cd main && mvn versions:set -B -ntp -DnewVersion=$RELEASE && git commit --allow-empty -am "Update version to $RELEASE" && git tag --force $RELEASE)
+          (cd combined && mvn versions:set -B -ntp -DnewVersion=$RELEASE)
+          (cd combined/pass-core && git commit --allow-empty -am "Update version to $RELEASE" && git tag --force $RELEASE)
+          (cd combined/pass-support && git commit --allow-empty -am "Update version to $RELEASE" && git tag --force $RELEASE)
+
+      - name: Release Java modules
+        if: ${{ ! env.ALL_JAVA_REPOS_TAG_EXISTS }}
+        uses: ./main/.github/actions/maven-release
+        with:
+          repodir: combined
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Push Release Docker images to GHCR ~ Java Repositories
+        if: ${{ ! env.ALL_JAVA_REPOS_TAG_EXISTS }}
+        run: |
+          docker push ghcr.io/eclipse-pass/pass-core-main:$RELEASE
+          docker push ghcr.io/eclipse-pass/deposit-services-core:$RELEASE
+          docker push ghcr.io/eclipse-pass/pass-notification-service:$RELEASE
+          docker push ghcr.io/eclipse-pass/jhu-grant-loader:$RELEASE
+          docker push ghcr.io/eclipse-pass/pass-journal-loader:$RELEASE
+          docker push ghcr.io/eclipse-pass/pass-nihms-loader:$RELEASE
+
+      - name: Push the Release commits and tags ~ Java Repositories
+        if: ${{ ! env.ALL_JAVA_REPOS_TAG_EXISTS }}
+        run: |
+          (cd main && git push origin && git push origin --force --tags)
+          (cd combined/pass-core && git push origin && git push origin --force --tags)
+          (cd combined/pass-support && git push origin && git push origin --force --tags)
+
+      - name: Create GitHub main release ~ Java Repositories
+        if: ${{ ! env.ALL_JAVA_REPOS_TAG_EXISTS }}
+        run: |
+          gh release delete "$RELEASE" --repo=eclipse-pass/main || true
+          gh release create "$RELEASE" --repo=eclipse-pass/main --generate-notes
+          gh release delete "$RELEASE" --repo=eclipse-pass/pass-core || true
+          gh release create "$RELEASE" --repo=eclipse-pass/pass-core --generate-notes
+          gh release delete "$RELEASE" --repo=eclipse-pass/pass-support || true
+          gh release create "$RELEASE" --repo=eclipse-pass/pass-support --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.JAVA_RELEASE_PAT }}
+
+      - name: Set Release/commit/tag ~ pass-ui
+        if: ${{ ! env.PASS_UI_TAG_EXISTS }}
+        uses: ./main/.github/actions/yarn-version
+        with:
+          repository_dir: combined/pass-ui
+        env:
+          RELEASE: ${{ env.RELEASE }}
+
+      - name: Build Release pass-ui
+        if: ${{ ! env.PASS_UI_TAG_EXISTS }}
+        uses: ./main/.github/actions/yarn-build
+        with:
+          repository_dir: combined/pass-ui
+          env_path: ../pass-docker/.env
+
+      - name: Push Release Docker images to GHCR ~ pass-ui
+        if: ${{ ! env.PASS_UI_TAG_EXISTS }}
+        run: docker push ghcr.io/eclipse-pass/pass-ui:$RELEASE
+
+      - name: Push the Release commits and tags ~ pass-ui
+        if: ${{ ! env.PASS_UI_TAG_EXISTS }}
+        run: cd combined/pass-ui && git push origin && git push origin --tags
+
+      - name: Create GitHub main release ~ pass-ui
+        if: ${{ ! env.PASS_UI_TAG_EXISTS }}
+        run: gh release create "$RELEASE" --repo=eclipse-pass/pass-ui --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.JAVA_RELEASE_PAT }}
+
+      - name: Set Release/commit/tag ~ pass-acceptance-testing
+        if: ${{ ! env.PASS_ACCPT_TEST_TAG_EXISTS }}
+        uses: ./main/.github/actions/yarn-version
+        with:
+          repository_dir: combined/pass-acceptance-testing
+        env:
+          RELEASE: ${{ env.RELEASE }}
+
+      - name: Push the Release commits and tags ~ pass-acceptance-testing
+        if: ${{ ! env.PASS_ACCPT_TEST_TAG_EXISTS }}
+        run: cd combined/pass-acceptance-testing && git push origin && git push origin --tags
+
+      - name: Create GitHub main release ~ pass-acceptance-testing
+        if: ${{ ! env.PASS_ACCPT_TEST_TAG_EXISTS }}
+        run: gh release create "$RELEASE" --repo=eclipse-pass/pass-acceptance-testing --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.JAVA_RELEASE_PAT }}
+
+      - name: Set Release/commit/tag ~ pass-docker
+        if: ${{ ! env.PASS_DOCKER_TAG_EXISTS }}
+        run: |
+          cd combined/pass-docker
+          sed -i "/^PASS_VERSION/s/.*/PASS_VERSION=$RELEASE/" .env
+          git commit --allow-empty -am "Update version to $RELEASE"
+          git tag $RELEASE
+
+      - name: Build Release pass-docker images
+        if: ${{ ! env.PASS_DOCKER_TAG_EXISTS }}
         working-directory: combined/pass-docker
         run: docker compose -f docker-compose.yml -f eclipse-pass.local.yml build idp ldap
 
-      - name: Set the next dev version and commit the change
+      - name: Push Release Docker images to GHCR ~ pass-docker
+        if: ${{ ! env.PASS_DOCKER_TAG_EXISTS }}
         run: |
-          (cd main && mvn versions:set -B -ntp -DallowSnapshots=true -DnewVersion=$NEXT && git commit -am "Update version to $NEXT")
+          docker push ghcr.io/eclipse-pass/demo-ldap:$RELEASE
+          docker push ghcr.io/eclipse-pass/idp:$RELEASE
+
+      - name: Push the Release commits and tags ~ pass-docker
+        if: ${{ ! env.PASS_DOCKER_TAG_EXISTS }}
+        run: cd combined/pass-docker && git push origin && git push origin --tags
+
+      - name: Create GitHub main release ~ pass-docker
+        if: ${{ ! env.PASS_DOCKER_TAG_EXISTS }}
+        run: gh release create "$RELEASE" --repo=eclipse-pass/pass-docker --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.JAVA_RELEASE_PAT }}
+
+      - name: Set Snapshot/commit ~ Java Repositories
+        run: |
+          (cd main && mvn versions:set -B -ntp -DallowSnapshots=true -DnewVersion=$NEXT && git commit --allow-empty -am "Update version to $NEXT")
           (cd combined && mvn versions:set -B -ntp -DallowSnapshots=true -DnewVersion=$NEXT)
-          (cd combined/pass-core && git commit -am "Update version to $NEXT")
-          (cd combined/pass-support && git commit -am "Update version to $NEXT")
-          (cd combined/pass-ui && yarn install --frozen-lockfile && yarn version --new-version $NEXT && git commit -am "Update version to $NEXT")
-          (cd combined/pass-acceptance-testing && yarn install --frozen-lockfile && yarn version --new-version $NEXT && git commit -am "Update version to $NEXT")
-          (cd combined/pass-docker && sed -i "/^PASS_VERSION/s/.*/PASS_VERSION=$NEXT/" .env && git commit -am "Update version to $NEXT")
+          (cd combined/pass-core && git commit --allow-empty -am "Update version to $NEXT")
+          (cd combined/pass-support && git commit --allow-empty -am "Update version to $NEXT")
 
-      #      - name: Release dev Java modules
-#        working-directory: combined
-#        run: |
-#          mvn -B -V -ntp -P release clean deploy -DskipTests -DskipITs
-#        env:
-#          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-#          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-#          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      - name: Release Snapshot Java modules
+        working-directory: combined
+        run: |
+          mvn -B -V -ntp -P release clean deploy -DskipTests -DskipITs
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
-#      - name: Login to GHCR
-#        uses: docker/login-action@v2
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.actor }}
-#          password: ${{ secrets.JAVA_RELEASE_PAT }}
-#
-#      - name: Push Docker images to GHCR
-#        run: |
-#          docker push ghcr.io/eclipse-pass/pass-core-main:$RELEASE
-#          docker push ghcr.io/eclipse-pass/pass-core-main:$NEXT
-#          docker push ghcr.io/eclipse-pass/deposit-services-core:$RELEASE
-#          docker push ghcr.io/eclipse-pass/deposit-services-core:$NEXT
-#          docker push ghcr.io/eclipse-pass/pass-notification-service:$RELEASE
-#          docker push ghcr.io/eclipse-pass/pass-notification-service:$NEXT
-#          docker push ghcr.io/eclipse-pass/jhu-grant-loader:$RELEASE
-#          docker push ghcr.io/eclipse-pass/jhu-grant-loader:$NEXT
-#          docker push ghcr.io/eclipse-pass/pass-journal-loader:$RELEASE
-#          docker push ghcr.io/eclipse-pass/pass-journal-loader:$NEXT
-#          docker push ghcr.io/eclipse-pass/pass-nihms-loader:$RELEASE
-#          docker push ghcr.io/eclipse-pass/pass-nihms-loader:$NEXT
-#
-#      - name: Push the commits and tags
-#        run: |
-#          (cd main && git push origin && git push origin --tags)
-#          (cd combined/pass-core && git push origin && git push origin --tags)
-#          (cd combined/pass-support && git push origin && git push origin --tags)
-#
-#      - name: Create GitHub main release
-#        run: |
-#          gh release create "$RELEASE" --repo=eclipse-pass/main --generate-notes
-#          gh release create "$RELEASE" --repo=eclipse-pass/pass-core --generate-notes
-#          gh release create "$RELEASE" --repo=eclipse-pass/pass-support --generate-notes
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.JAVA_RELEASE_PAT }}
+      - name: Push Snapshot Docker images to GHCR ~ Java Repositories
+        run: |
+          docker push ghcr.io/eclipse-pass/pass-core-main:$NEXT
+          docker push ghcr.io/eclipse-pass/deposit-services-core:$NEXT
+          docker push ghcr.io/eclipse-pass/pass-notification-service:$NEXT
+          docker push ghcr.io/eclipse-pass/jhu-grant-loader:$NEXT
+          docker push ghcr.io/eclipse-pass/pass-journal-loader:$NEXT
+          docker push ghcr.io/eclipse-pass/pass-nihms-loader:$NEXT
+
+      - name: Push the Snapshot commits ~ Java Repositories
+        run: |
+          (cd main && git push origin)
+          (cd combined/pass-core && git push origin)
+          (cd combined/pass-support && git push origin)
+
+      - name: Set Snapshot/commit ~ pass-ui
+        uses: ./main/.github/actions/yarn-version
+        with:
+          repository_dir: combined/pass-ui
+          skip_tag: "true"
+        env:
+          RELEASE: ${{ env.NEXT }}
+
+      - name: Build Snapshot pass-ui
+        uses: ./main/.github/actions/yarn-build
+        with:
+          repository_dir: combined/pass-ui
+          env_path: ../pass-docker/.env
+          is_dev: "true"
+
+      - name: Push Snapshot Docker images to GHCR ~ pass-ui
+        run: docker push ghcr.io/eclipse-pass/pass-ui:$NEXT
+
+      - name: Push the Snapshot commits ~ pass-ui
+        run: cd combined/pass-ui && git push origin
+
+      - name: Set Snapshot/commit ~ pass-acceptance-testing
+        uses: ./main/.github/actions/yarn-version
+        with:
+          repository_dir: combined/pass-acceptance-testing
+          skip_tag: "true"
+        env:
+          RELEASE: ${{ env.NEXT }}
+
+      - name: Push the Snapshot commits ~ pass-acceptance-testing
+        run: cd combined/pass-acceptance-testing && git push origin
+
+      - name: Set Snapshot/commit ~ pass-docker
+        run: |
+          cd combined/pass-docker
+          sed -i "/^PASS_VERSION/s/.*/PASS_VERSION=$NEXT/" .env
+          git commit --allow-empty -am "Update version to $NEXT"
+
+      - name: Build Snapshot pass-docker images
+        working-directory: combined/pass-docker
+        run: docker compose -f docker-compose.yml -f eclipse-pass.local.yml build idp ldap
+
+      - name: Push Snapshot Docker images to GHCR ~ pass-docker
+        run: |
+          docker push ghcr.io/eclipse-pass/demo-ldap:$NEXT
+          docker push ghcr.io/eclipse-pass/idp:$NEXT
+
+      - name: Push the Snapshot commits ~ pass-docker
+        run: cd combined/pass-docker && git push origin

--- a/.github/workflows/pass-complete-release.yml
+++ b/.github/workflows/pass-complete-release.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       RELEASE: ${{ inputs.releaseversion }}
       NEXT: ${{ inputs.nextversion }}
+      NEXT_TAG: ${{ inputs.nextversion }}-init
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -119,9 +120,9 @@ jobs:
       - name: Push the Release commits and tags ~ Java Repositories
         if: ${{ ! env.ALL_JAVA_REPOS_TAG_EXISTS }}
         run: |
-          (cd main && git push origin && git push origin --force --tags)
-          (cd combined/pass-core && git push origin && git push origin --force --tags)
-          (cd combined/pass-support && git push origin && git push origin --force --tags)
+          (cd main && git push --atomic origin --force $RELEASE)
+          (cd combined/pass-core && git push --atomic origin --force $RELEASE)
+          (cd combined/pass-support && git push --atomic origin --force $RELEASE)
 
       - name: Create GitHub main release ~ Java Repositories
         if: ${{ ! env.ALL_JAVA_REPOS_TAG_EXISTS }}
@@ -142,6 +143,7 @@ jobs:
           repository_dir: combined/pass-ui
         env:
           RELEASE: ${{ env.RELEASE }}
+          RELEASE_TAG: ${{ env.RELEASE }}
 
       - name: Build Release pass-ui
         if: ${{ ! env.PASS_UI_TAG_EXISTS }}
@@ -156,7 +158,7 @@ jobs:
 
       - name: Push the Release commits and tags ~ pass-ui
         if: ${{ ! env.PASS_UI_TAG_EXISTS }}
-        run: cd combined/pass-ui && git push origin && git push origin --tags
+        run: cd combined/pass-ui && git push --atomic origin --force $RELEASE
 
       - name: Create GitHub main release ~ pass-ui
         if: ${{ ! env.PASS_UI_TAG_EXISTS }}
@@ -171,10 +173,11 @@ jobs:
           repository_dir: combined/pass-acceptance-testing
         env:
           RELEASE: ${{ env.RELEASE }}
+          RELEASE_TAG: ${{ env.RELEASE }}
 
       - name: Push the Release commits and tags ~ pass-acceptance-testing
         if: ${{ ! env.PASS_ACCPT_TEST_TAG_EXISTS }}
-        run: cd combined/pass-acceptance-testing && git push origin && git push origin --tags
+        run: cd combined/pass-acceptance-testing && git push --atomic origin --force $RELEASE
 
       - name: Create GitHub main release ~ pass-acceptance-testing
         if: ${{ ! env.PASS_ACCPT_TEST_TAG_EXISTS }}
@@ -188,7 +191,7 @@ jobs:
           cd combined/pass-docker
           sed -i "/^PASS_VERSION/s/.*/PASS_VERSION=$RELEASE/" .env
           git commit --allow-empty -am "Update version to $RELEASE"
-          git tag $RELEASE
+          git tag --force $RELEASE
 
       - name: Build Release pass-docker images
         if: ${{ ! env.PASS_DOCKER_TAG_EXISTS }}
@@ -203,7 +206,7 @@ jobs:
 
       - name: Push the Release commits and tags ~ pass-docker
         if: ${{ ! env.PASS_DOCKER_TAG_EXISTS }}
-        run: cd combined/pass-docker && git push origin && git push origin --tags
+        run: cd combined/pass-docker && git push --atomic origin --force $RELEASE
 
       - name: Create GitHub main release ~ pass-docker
         if: ${{ ! env.PASS_DOCKER_TAG_EXISTS }}
@@ -213,10 +216,10 @@ jobs:
 
       - name: Set Snapshot/commit ~ Java Repositories
         run: |
-          (cd main && mvn versions:set -B -ntp -DallowSnapshots=true -DnewVersion=$NEXT && git commit --allow-empty -am "Update version to $NEXT")
+          (cd main && mvn versions:set -B -ntp -DallowSnapshots=true -DnewVersion=$NEXT && git commit --allow-empty -am "Update version to $NEXT" && git tag --force $NEXT_TAG)
           (cd combined && mvn versions:set -B -ntp -DallowSnapshots=true -DnewVersion=$NEXT)
-          (cd combined/pass-core && git commit --allow-empty -am "Update version to $NEXT")
-          (cd combined/pass-support && git commit --allow-empty -am "Update version to $NEXT")
+          (cd combined/pass-core && git commit --allow-empty -am "Update version to $NEXT" && git tag --force $NEXT_TAG)
+          (cd combined/pass-support && git commit --allow-empty -am "Update version to $NEXT" && git tag --force $NEXT_TAG)
 
       - name: Release Snapshot Java modules
         working-directory: combined
@@ -238,17 +241,17 @@ jobs:
 
       - name: Push the Snapshot commits ~ Java Repositories
         run: |
-          (cd main && git push origin)
-          (cd combined/pass-core && git push origin)
-          (cd combined/pass-support && git push origin)
+          (cd main && git push --atomic origin --force $NEXT_TAG)
+          (cd combined/pass-core && git push --atomic origin --force $NEXT_TAG)
+          (cd combined/pass-support && git push --atomic origin --force $NEXT_TAG)
 
       - name: Set Snapshot/commit ~ pass-ui
         uses: ./main/.github/actions/yarn-version
         with:
           repository_dir: combined/pass-ui
-          skip_tag: "true"
         env:
           RELEASE: ${{ env.NEXT }}
+          RELEASE_TAG: ${{ env.NEXT_TAG }}
 
       - name: Build Snapshot pass-ui
         uses: ./main/.github/actions/yarn-build
@@ -261,24 +264,25 @@ jobs:
         run: docker push ghcr.io/eclipse-pass/pass-ui:$NEXT
 
       - name: Push the Snapshot commits ~ pass-ui
-        run: cd combined/pass-ui && git push origin
+        run: cd combined/pass-ui && git push --atomic origin --force $NEXT_TAG
 
       - name: Set Snapshot/commit ~ pass-acceptance-testing
         uses: ./main/.github/actions/yarn-version
         with:
           repository_dir: combined/pass-acceptance-testing
-          skip_tag: "true"
         env:
           RELEASE: ${{ env.NEXT }}
+          RELEASE_TAG: ${{ env.NEXT_TAG }}
 
       - name: Push the Snapshot commits ~ pass-acceptance-testing
-        run: cd combined/pass-acceptance-testing && git push origin
+        run: cd combined/pass-acceptance-testing && git push --atomic origin --force $NEXT_TAG
 
       - name: Set Snapshot/commit ~ pass-docker
         run: |
           cd combined/pass-docker
           sed -i "/^PASS_VERSION/s/.*/PASS_VERSION=$NEXT/" .env
           git commit --allow-empty -am "Update version to $NEXT"
+          git tag --force $NEXT_TAG
 
       - name: Build Snapshot pass-docker images
         working-directory: combined/pass-docker
@@ -290,4 +294,4 @@ jobs:
           docker push ghcr.io/eclipse-pass/idp:$NEXT
 
       - name: Push the Snapshot commits ~ pass-docker
-        run: cd combined/pass-docker && git push origin
+        run: cd combined/pass-docker && git push --atomic origin --force $NEXT_TAG


### PR DESCRIPTION
This is a workflow that will release all PASS modules.  It builds on the approach in the Release Java Modules.  The workflow requires a `Release Version` and `Next dev version` as input.  In order to run the workflow, a PAT needs to be set like instructed in the Release Java Workflow instructions.

I tried to make the workflow so that is can be re-run in the case where one of the steps fails for some reason.  As one can see, there are several steps where failure can occur, so the workflow may not be re-runnable in all failure scenarios, but should cover the most common cases.

I will work on updating the release documentation once this workflow is reviewed/merged.

Note, I had to merge an initial version of `pass-complete-release.yml` to main so I could run tests, thus the diff in the file instead of being new.

