### PR TITLE
Fix complete release workflow push issue

### DIFF
--- a/.github/actions/yarn-version/action.yml
+++ b/.github/actions/yarn-version/action.yml
@@ -6,6 +6,10 @@ inputs:
   repository_dir:
     description: 'Directory of repository to update'
     required: true
+  skip_tag:
+    description: 'Skip git tag'
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -20,4 +24,7 @@ runs:
         yarn config set version-git-tag false
         yarn version --new-version $RELEASE
         git commit --allow-empty -am "Update version to $RELEASE"
-        git tag --force $RELEASE_TAG
+        if [ "$SKIP_TAG" == "false" ]; then
+          echo "Tagging yarn version $RELEASE"
+          git tag $RELEASE
+        fi

--- a/.github/workflows/pass-complete-release.yml
+++ b/.github/workflows/pass-complete-release.yml
@@ -120,9 +120,9 @@ jobs:
       - name: Push the Release commits and tags ~ Java Repositories
         if: ${{ ! env.ALL_JAVA_REPOS_TAG_EXISTS }}
         run: |
-          (cd main && git push --atomic origin --force $RELEASE)
-          (cd combined/pass-core && git push --atomic origin --force $RELEASE)
-          (cd combined/pass-support && git push --atomic origin --force $RELEASE)
+          (cd main && git push --atomic origin main --force $RELEASE)
+          (cd combined/pass-core && git push --atomic origin main --force $RELEASE)
+          (cd combined/pass-support && git push --atomic origin main --force $RELEASE)
 
       - name: Create GitHub main release ~ Java Repositories
         if: ${{ ! env.ALL_JAVA_REPOS_TAG_EXISTS }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Push the Release commits and tags ~ pass-ui
         if: ${{ ! env.PASS_UI_TAG_EXISTS }}
-        run: cd combined/pass-ui && git push --atomic origin --force $RELEASE
+        run: cd combined/pass-ui && git push --atomic origin main --force $RELEASE
 
       - name: Create GitHub main release ~ pass-ui
         if: ${{ ! env.PASS_UI_TAG_EXISTS }}
@@ -177,7 +177,7 @@ jobs:
 
       - name: Push the Release commits and tags ~ pass-acceptance-testing
         if: ${{ ! env.PASS_ACCPT_TEST_TAG_EXISTS }}
-        run: cd combined/pass-acceptance-testing && git push --atomic origin --force $RELEASE
+        run: cd combined/pass-acceptance-testing && git push --atomic origin main --force $RELEASE
 
       - name: Create GitHub main release ~ pass-acceptance-testing
         if: ${{ ! env.PASS_ACCPT_TEST_TAG_EXISTS }}
@@ -206,7 +206,7 @@ jobs:
 
       - name: Push the Release commits and tags ~ pass-docker
         if: ${{ ! env.PASS_DOCKER_TAG_EXISTS }}
-        run: cd combined/pass-docker && git push --atomic origin --force $RELEASE
+        run: cd combined/pass-docker && git push --atomic origin main --force $RELEASE
 
       - name: Create GitHub main release ~ pass-docker
         if: ${{ ! env.PASS_DOCKER_TAG_EXISTS }}
@@ -241,9 +241,9 @@ jobs:
 
       - name: Push the Snapshot commits ~ Java Repositories
         run: |
-          (cd main && git push --atomic origin --force $NEXT_TAG)
-          (cd combined/pass-core && git push --atomic origin --force $NEXT_TAG)
-          (cd combined/pass-support && git push --atomic origin --force $NEXT_TAG)
+          (cd main && git push --atomic origin main --force $NEXT_TAG)
+          (cd combined/pass-core && git push --atomic origin main --force $NEXT_TAG)
+          (cd combined/pass-support && git push --atomic origin main --force $NEXT_TAG)
 
       - name: Set Snapshot/commit ~ pass-ui
         uses: ./main/.github/actions/yarn-version
@@ -264,7 +264,7 @@ jobs:
         run: docker push ghcr.io/eclipse-pass/pass-ui:$NEXT
 
       - name: Push the Snapshot commits ~ pass-ui
-        run: cd combined/pass-ui && git push --atomic origin --force $NEXT_TAG
+        run: cd combined/pass-ui && git push --atomic origin main --force $NEXT_TAG
 
       - name: Set Snapshot/commit ~ pass-acceptance-testing
         uses: ./main/.github/actions/yarn-version
@@ -275,7 +275,7 @@ jobs:
           RELEASE_TAG: ${{ env.NEXT_TAG }}
 
       - name: Push the Snapshot commits ~ pass-acceptance-testing
-        run: cd combined/pass-acceptance-testing && git push --atomic origin --force $NEXT_TAG
+        run: cd combined/pass-acceptance-testing && git push --atomic origin main --force $NEXT_TAG
 
       - name: Set Snapshot/commit ~ pass-docker
         run: |
@@ -294,4 +294,4 @@ jobs:
           docker push ghcr.io/eclipse-pass/idp:$NEXT
 
       - name: Push the Snapshot commits ~ pass-docker
-        run: cd combined/pass-docker && git push --atomic origin --force $NEXT_TAG
+        run: cd combined/pass-docker && git push --atomic origin main --force $NEXT_TAG

--- a/.github/workflows/pass-complete-release.yml
+++ b/.github/workflows/pass-complete-release.yml
@@ -17,7 +17,6 @@ jobs:
     env:
       RELEASE: ${{ inputs.releaseversion }}
       NEXT: ${{ inputs.nextversion }}
-      NEXT_TAG: ${{ inputs.nextversion }}-init
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -143,7 +142,6 @@ jobs:
           repository_dir: combined/pass-ui
         env:
           RELEASE: ${{ env.RELEASE }}
-          RELEASE_TAG: ${{ env.RELEASE }}
 
       - name: Build Release pass-ui
         if: ${{ ! env.PASS_UI_TAG_EXISTS }}
@@ -173,7 +171,6 @@ jobs:
           repository_dir: combined/pass-acceptance-testing
         env:
           RELEASE: ${{ env.RELEASE }}
-          RELEASE_TAG: ${{ env.RELEASE }}
 
       - name: Push the Release commits and tags ~ pass-acceptance-testing
         if: ${{ ! env.PASS_ACCPT_TEST_TAG_EXISTS }}
@@ -216,10 +213,10 @@ jobs:
 
       - name: Set Snapshot/commit ~ Java Repositories
         run: |
-          (cd main && mvn versions:set -B -ntp -DallowSnapshots=true -DnewVersion=$NEXT && git commit --allow-empty -am "Update version to $NEXT" && git tag --force $NEXT_TAG)
+          (cd main && mvn versions:set -B -ntp -DallowSnapshots=true -DnewVersion=$NEXT && git commit --allow-empty -am "Update version to $NEXT")
           (cd combined && mvn versions:set -B -ntp -DallowSnapshots=true -DnewVersion=$NEXT)
-          (cd combined/pass-core && git commit --allow-empty -am "Update version to $NEXT" && git tag --force $NEXT_TAG)
-          (cd combined/pass-support && git commit --allow-empty -am "Update version to $NEXT" && git tag --force $NEXT_TAG)
+          (cd combined/pass-core && git commit --allow-empty -am "Update version to $NEXT")
+          (cd combined/pass-support && git commit --allow-empty -am "Update version to $NEXT")
 
       - name: Release Snapshot Java modules
         working-directory: combined
@@ -241,17 +238,17 @@ jobs:
 
       - name: Push the Snapshot commits ~ Java Repositories
         run: |
-          (cd main && git push --atomic origin main --force $NEXT_TAG)
-          (cd combined/pass-core && git push --atomic origin main --force $NEXT_TAG)
-          (cd combined/pass-support && git push --atomic origin main --force $NEXT_TAG)
+          (cd main && git push origin main)
+          (cd combined/pass-core && git push origin main)
+          (cd combined/pass-support && git push origin main)
 
       - name: Set Snapshot/commit ~ pass-ui
         uses: ./main/.github/actions/yarn-version
         with:
           repository_dir: combined/pass-ui
+          skip_tag: "true"
         env:
           RELEASE: ${{ env.NEXT }}
-          RELEASE_TAG: ${{ env.NEXT_TAG }}
 
       - name: Build Snapshot pass-ui
         uses: ./main/.github/actions/yarn-build
@@ -264,25 +261,24 @@ jobs:
         run: docker push ghcr.io/eclipse-pass/pass-ui:$NEXT
 
       - name: Push the Snapshot commits ~ pass-ui
-        run: cd combined/pass-ui && git push --atomic origin main --force $NEXT_TAG
+        run: cd combined/pass-ui && git push origin main
 
       - name: Set Snapshot/commit ~ pass-acceptance-testing
         uses: ./main/.github/actions/yarn-version
         with:
           repository_dir: combined/pass-acceptance-testing
+          skip_tag: "true"
         env:
           RELEASE: ${{ env.NEXT }}
-          RELEASE_TAG: ${{ env.NEXT_TAG }}
 
       - name: Push the Snapshot commits ~ pass-acceptance-testing
-        run: cd combined/pass-acceptance-testing && git push --atomic origin main --force $NEXT_TAG
+        run: cd combined/pass-acceptance-testing && git push origin main
 
       - name: Set Snapshot/commit ~ pass-docker
         run: |
           cd combined/pass-docker
           sed -i "/^PASS_VERSION/s/.*/PASS_VERSION=$NEXT/" .env
           git commit --allow-empty -am "Update version to $NEXT"
-          git tag --force $NEXT_TAG
 
       - name: Build Snapshot pass-docker images
         working-directory: combined/pass-docker
@@ -294,4 +290,4 @@ jobs:
           docker push ghcr.io/eclipse-pass/idp:$NEXT
 
       - name: Push the Snapshot commits ~ pass-docker
-        run: cd combined/pass-docker && git push --atomic origin main --force $NEXT_TAG
+        run: cd combined/pass-docker && git push origin main


### PR DESCRIPTION
Apparently, when using the --atomic argument of push, you must specify the branch if pushing a tag too.

Also removes the tagging of the snapshots.  This is no longer needed because the `tags-ignore` did not work for the repo workflows, had to go with another approach that doesn't depend on tags.