### PR TITLE
Use git-tag-version flag on pnpm version command

### DIFF
--- a/.github/actions/node-version/action.yml
+++ b/.github/actions/node-version/action.yml
@@ -25,8 +25,7 @@ runs:
         SKIP_TAG: ${{ inputs.skip_tag }}
       run: |
         pnpm install --frozen-lockfile
-        pnpm config set version-git-tag false
-        pnpm version --new-version $RELEASE
+        pnpm version --git-tag-version false --new-version $RELEASE
         git commit --allow-empty -am "Update version to $RELEASE"
         if [ "$SKIP_TAG" == "false" ]; then
           echo "Tagging version $RELEASE"


### PR DESCRIPTION
So that when pass-ui is released, we only get one commit per version update (release and snapshot).