### PR TITLE
Add cyclonedx maven plugin to create SBOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
     <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
     <tidy-maven-plugin.version>1.3.0</tidy-maven-plugin.version>
+    <cyclonedx-maven-plugin.version>2.8.2</cyclonedx-maven-plugin.version>
 
     <checkstyle.version>8.41.1</checkstyle.version>
     <duraspace-codestyle.version>1.1.0</duraspace-codestyle.version>
@@ -280,6 +281,26 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${maven-failsafe-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>${cyclonedx-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <phase>generate-resources</phase>
+              <goals>
+                <goal>makeAggregateBom</goal>
+              </goals>
+              <configuration>
+                <projectType>application</projectType>
+                <outputDirectory>${project.build.outputDirectory}/META-INF/sbom</outputDirectory>
+                <outputFormat>json</outputFormat>
+                <outputName>application.cdx</outputName>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -22,38 +22,38 @@
       <name>Jim Martino</name>
       <email>jrm@jhu.edu</email>
       <organization>The Sheridan Libraries, Johns Hopkins University</organization>
-      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
     </developer>
     <developer>
       <name>Mark Patton</name>
       <email>mpatton@jhu.edu</email>
       <organization>The Sheridan Libraries, Johns Hopkins University</organization>
-      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
     </developer>
     <developer>
       <name>John Abrahams</name>
       <email>jabrah20@jhu.edu</email>
       <organization>The Sheridan Libraries, Johns Hopkins University</organization>
-      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
     </developer>
     <developer>
       <name>Tim Sanders</name>
       <email>tsande16@jhu.edu</email>
       <organization>The Sheridan Libraries, Johns Hopkins University</organization>
-      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
     </developer>
     <developer>
       <name>Russ Poetker</name>
       <email>rpoetke1@jhu.edu</email>
       <organization>The Sheridan Libraries, Johns Hopkins University</organization>
-      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
     </developer>
   </developers>
 
   <scm>
     <connection>scm:git:git://github.com/eclipse-pass/main.git</connection>
     <developerConnection>scm:git:ssh://github.com:eclipse-pass/main.git</developerConnection>
-    <url>http://github.com/eclipse-pass/main/tree/main</url>
+    <url>https://github.com/eclipse-pass/main/tree/main</url>
     <tag>HEAD</tag>
   </scm>
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
             <execution>
               <phase>generate-resources</phase>
               <goals>
-                <goal>makeAggregateBom</goal>
+                <goal>makeBom</goal>
               </goals>
               <configuration>
                 <projectType>application</projectType>


### PR DESCRIPTION
This PR add cyclonedx maven plugin to plugin management so the child projects (pass-core and pass-support) can create SBOMs.  There is also some general cleanup in the pom.