### PR TITLE
Support SBOM creation

### DIFF
--- a/.github/actions/node-build/action.yml
+++ b/.github/actions/node-build/action.yml
@@ -32,7 +32,7 @@ runs:
         pnpm install --frozen-lockfile
         pnpm run build
         if [ "CREATE_SBOM" == "true" ]; then
-          rm -f *-cyclonedx.json
+          rm -f *-cyclonedx-sbom.json
           pnpm run create_sbom
         fi
         pnpm run build:docker

--- a/.github/actions/node-build/action.yml
+++ b/.github/actions/node-build/action.yml
@@ -32,6 +32,7 @@ runs:
         pnpm install --frozen-lockfile
         pnpm run build
         if [ "CREATE_SBOM" == "true" ]; then
+          rm -f *-cyclonedx.json
           pnpm run create_sbom
         fi
         pnpm run build:docker

--- a/.github/actions/node-build/action.yml
+++ b/.github/actions/node-build/action.yml
@@ -9,10 +9,10 @@ inputs:
   env_path:
     description: 'Path to .env file'
     required: true
-  is_dev:
-    description: 'Is dev build'
+  create_sbom:
+    description: 'Create SBOM'
     required: false
-    default: "false"
+    default: "true"
 
 runs:
   using: composite
@@ -26,9 +26,12 @@ runs:
       working-directory: ${{ inputs.repository_dir }}
       env:
         ENV_FILE_PATH: ${{ inputs.env_path }}
-        IS_DEV: ${{ inputs.is_dev }}
+        CREATE_SBOM: ${{ inputs.create_sbom }}
       run: |
         export $(grep -v '^[#|SIGNING|PASS_CORE_POLICY]' $ENV_FILE_PATH | xargs -d '\n')
         pnpm install --frozen-lockfile
         pnpm run build
+        if [ "CREATE_SBOM" == "true" ]; then
+          pnpm run create_sbom
+        fi
         pnpm run build:docker

--- a/.github/workflows/pass-complete-release.yml
+++ b/.github/workflows/pass-complete-release.yml
@@ -200,7 +200,6 @@ jobs:
         with:
           repository_dir: combined/pass-ui
           env_path: ../pass-docker/.env
-          is_dev: "true"
 
       - name: Push Snapshot Docker images to GHCR ~ pass-ui
         if: ${{ ! env.PASS_UI_TAG_EXISTS }}

--- a/.github/workflows/pass-complete-release.yml
+++ b/.github/workflows/pass-complete-release.yml
@@ -160,8 +160,24 @@ jobs:
           gh release create "$RELEASE" --repo=eclipse-pass/main --generate-notes
           gh release delete "$RELEASE" --repo=eclipse-pass/pass-core || true
           gh release create "$RELEASE" --repo=eclipse-pass/pass-core --generate-notes
+          cp combined/pass-core/pass-core-main/target/classes/META-INF/sbom/application.cdx.json pass-core-main-$RELEASE-cyclonedx-sbom.json
+          gh release upload "$RELEASE" --repo=eclipse-pass/pass-core pass-core-main-$RELEASE-cyclonedx-sbom.json
           gh release delete "$RELEASE" --repo=eclipse-pass/pass-support || true
           gh release create "$RELEASE" --repo=eclipse-pass/pass-support --generate-notes
+          cp combined/pass-support/pass-data-client/target/classes/META-INF/sbom/application.cdx.json pass-data-client-$RELEASE-cyclonedx-sbom.json
+          gh release upload "$RELEASE" --repo=eclipse-pass/pass-support pass-data-client-$RELEASE-cyclonedx-sbom.json
+          cp combined/pass-support/pass-deposit-services/deposit-core/target/classes/META-INF/sbom/application.cdx.json deposit-core-$RELEASE-cyclonedx-sbom.json
+          gh release upload "$RELEASE" --repo=eclipse-pass/pass-support deposit-core-$RELEASE-cyclonedx-sbom.json
+          cp combined/pass-support/pass-grant-loader/target/classes/META-INF/sbom/application.cdx.json pass-grant-loader-$RELEASE-cyclonedx-sbom.json
+          gh release upload "$RELEASE" --repo=eclipse-pass/pass-support pass-grant-loader-$RELEASE-cyclonedx-sbom.json
+          cp combined/pass-support/pass-journal-loader/pass-journal-loader-nih/target/classes/META-INF/sbom/application.cdx.json pass-journal-loader-nih-$RELEASE-cyclonedx-sbom.json
+          gh release upload "$RELEASE" --repo=eclipse-pass/pass-support pass-journal-loader-nih-$RELEASE-cyclonedx-sbom.json
+          cp combined/pass-support/pass-nihms-loader/nihms-data-harvest/target/classes/META-INF/sbom/application.cdx.json nihms-data-harvest-$RELEASE-cyclonedx-sbom.json
+          gh release upload "$RELEASE" --repo=eclipse-pass/pass-support nihms-data-harvest-$RELEASE-cyclonedx-sbom.json
+          cp combined/pass-support/pass-nihms-loader/nihms-data-transform-load/target/classes/META-INF/sbom/application.cdx.json nihms-data-transform-load-$RELEASE-cyclonedx-sbom.json
+          gh release upload "$RELEASE" --repo=eclipse-pass/pass-support nihms-data-transform-load-$RELEASE-cyclonedx-sbom.json
+          cp combined/pass-support/pass-notification-service/target/classes/META-INF/sbom/application.cdx.json pass-notification-service-$RELEASE-cyclonedx-sbom.json
+          gh release upload "$RELEASE" --repo=eclipse-pass/pass-support pass-notification-service-$RELEASE-cyclonedx-sbom.json
         env:
           GITHUB_TOKEN: ${{ secrets.JAVA_RELEASE_PAT }}
 
@@ -183,7 +199,9 @@ jobs:
 
       - name: Push Release Docker images to GHCR ~ pass-ui
         if: ${{ ! env.PASS_UI_TAG_EXISTS }}
-        run: docker push ghcr.io/eclipse-pass/pass-ui:$RELEASE
+        run: |
+          docker push ghcr.io/eclipse-pass/pass-ui:$RELEASE
+          cp combined/pass-ui/pass-ui-$RELEASE-cyclonedx-sbom.json pass-ui-$RELEASE-cyclonedx-sbom.json
 
       - name: Set Snapshot/commit ~ pass-ui
         if: ${{ ! env.PASS_UI_TAG_EXISTS }}
@@ -211,7 +229,9 @@ jobs:
 
       - name: Create GitHub main release ~ pass-ui
         if: ${{ ! env.PASS_UI_TAG_EXISTS }}
-        run: gh release create "$RELEASE" --repo=eclipse-pass/pass-ui --generate-notes
+        run: |
+          gh release create "$RELEASE" --repo=eclipse-pass/pass-ui --generate-notes
+          gh release upload "$RELEASE" --repo=eclipse-pass/pass-ui pass-ui-$RELEASE-cyclonedx-sbom.json
         env:
           GITHUB_TOKEN: ${{ secrets.JAVA_RELEASE_PAT }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,7 @@
                 <outputDirectory>${project.build.outputDirectory}/META-INF/sbom</outputDirectory>
                 <outputFormat>json</outputFormat>
                 <outputName>application.cdx</outputName>
+                <classifier>cyclonedx-sbom</classifier>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
The following changes are in this PR:

- The node-action now has an input parameter to determine if a call to `create_sbom` script will happen.  Default is true for this input parameter.
- When creating the github Release, we now also upload the associated SBOMs for each component in the repo.

https://github.com/eclipse-pass/main/issues/767