### PR TITLE
Update Release Checklist URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist-issue.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist-issue.md
@@ -15,7 +15,7 @@ assignees: ''
 | Next dev version | MAJOR.MINOR.PATCH-SNAPSHOT |
 
 ## Release Process Overview
-This is the full detailed release process, including the steps that are performed by the GitHub automation: [Release](https://github.com/eclipse-pass/main/blob/main/docs/dev/release.md)
+This is the full detailed release process, including the steps that are performed by the GitHub automation: [Release](https://docs.eclipse-pass.org/developer-documentation/release)
 
 ## Pre-release
 
@@ -23,9 +23,11 @@ This is the full detailed release process, including the steps that are performe
 - [ ] Ensure all code commits and PRs intended for the release have been merged.
 - [ ] Issue a code freeze statement on the Eclipse PASS slack #pass-dev channel to notify all developers that a release is imminent.
 
-[Release Steps with Automations](https://github.com/eclipse-pass/main/blob/main/docs/dev/release-steps-with-automations.md)
+[Release Steps with Automations](https://docs.eclipse-pass.org/developer-documentation/release/release-steps-with-automations#release-all-projects)
 
 ## Release Projects
+
+**Reminder:** [Configure Personal Access Token (PAT) for the release.](https://docs.eclipse-pass.org/developer-documentation/release/release-steps-with-automations#github-personal-access-token-setup)
 
 [Release All Modules Workflow](https://github.com/eclipse-pass/main/actions/workflows/pass-complete-release.yml)
 
@@ -39,9 +41,9 @@ This is the full detailed release process, including the steps that are performe
 ## Post-release
 
 - [ ] Test the release by using the [acceptance test workflow](https://github.com/eclipse-pass/pass-acceptance-testing/actions/workflows/test.yml). Enter the release number into the Ref field.
-- [ ] Check that correct tickets are in the release milestone. [GitHub Ticket Update](https://github.com/eclipse-pass/main/blob/main/docs/dev/release.md#update-release-notes)
-- [ ] Write release notes in the [Release Notes doc](https://github.com/eclipse-pass/main/blob/main/docs/release-notes.md), submit a PR for the changes, and ensure the PR is merged. Release Notes should be written to be understandable by community members who are not technical.
+- [ ] Check that correct tickets are in the release milestone. [GitHub Ticket Update](https://docs.eclipse-pass.org/developer-documentation/release#update-release-notes)
+- [ ] Write release notes in the [Release Notes doc](https://github.com/eclipse-pass/pass-documentation/blob/main/community/release-notes.md), submit a PR for the changes, and ensure the PR is merged. Release Notes should be written to be understandable by community members who are not technical.
 - [ ] Draft release message and have technical & community lead provide feedback. Ensure that a link to the release notes is included in the release message.
-- [ ] Post a message about the release to the PASS Google Group.  [Notes about the PASS Google Group](https://github.com/eclipse-pass/main/blob/main/docs/dev/release.md#process)
+- [ ] Post a message about the release to the PASS Google Group.  [Notes about the PASS Google Group](https://docs.eclipse-pass.org/developer-documentation/release#process)
 - [ ] Update [Pass Demo](https://demo.eclipse-pass.org) to new release - [Publish to SNS Topic action](https://github.com/eclipse-pass/main/actions/workflows/deployToAWS.yml) using `Environment: demo`
 - [ ] Send message to Eclipse PASS slack #pass-dev channel that the release is complete.


### PR DESCRIPTION
This PR introduces updates to the URLs in the release checklist issue. It changes them from the old doc repository to the new documentation [site](https://docs.eclipse-pass.org/). In addition it has a reminder to configure the PAT before starting the release workflow.