### PR TITLE
Change Release Notes step to Pre-release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist-issue.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist-issue.md
@@ -22,6 +22,7 @@ This is the full detailed release process, including the steps that are performe
 - [ ] Identify the version to be utilized for the release.
 - [ ] Ensure all code commits and PRs intended for the release have been merged.
 - [ ] Issue a code freeze statement on the Eclipse PASS slack #pass-dev channel to notify all developers that a release is imminent.
+- [ ] Write release notes in the [Release Notes doc](https://github.com/eclipse-pass/pass-documentation/blob/main/community/release-notes.md), submit a PR for the changes, and ensure the PR is merged. Release Notes should be written to be understandable by community members who are not technical.
 
 [Release Steps with Automations](https://docs.eclipse-pass.org/developer-documentation/release/release-steps-with-automations#release-all-projects)
 
@@ -37,12 +38,12 @@ This is the full detailed release process, including the steps that are performe
 - [ ] Release Pass UI
 - [ ] Release Pass Acceptance Testing
 - [ ] Release Pass Docker
+- [ ] Release Pass Documentation
 
 ## Post-release
 
 - [ ] Test the release by using the [acceptance test workflow](https://github.com/eclipse-pass/pass-acceptance-testing/actions/workflows/test.yml). Enter the release number into the Ref field.
 - [ ] Check that correct tickets are in the release milestone. [GitHub Ticket Update](https://docs.eclipse-pass.org/developer-documentation/release#update-release-notes)
-- [ ] Write release notes in the [Release Notes doc](https://github.com/eclipse-pass/pass-documentation/blob/main/community/release-notes.md), submit a PR for the changes, and ensure the PR is merged. Release Notes should be written to be understandable by community members who are not technical.
 - [ ] Draft release message and have technical & community lead provide feedback. Ensure that a link to the release notes is included in the release message.
 - [ ] Post a message about the release to the PASS Google Group.  [Notes about the PASS Google Group](https://docs.eclipse-pass.org/developer-documentation/release#process)
 - [ ] Update [Pass Demo](https://demo.eclipse-pass.org) to new release - [Publish to SNS Topic action](https://github.com/eclipse-pass/main/actions/workflows/deployToAWS.yml) using `Environment: demo`


### PR DESCRIPTION
As discussed in the pass status call, moved the Release Notes step to the Pre-release section.