### PR TITLE
Setup SonarQube Code Coverage Analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,18 @@ jobs:
         uses: eclipse-pass/main/.github/actions/acceptance-test@main
         with:
           pullimages: missing
+
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print description
+        run: |
+          echo "Running SonarQube Scanner"
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: SonarQubeScan
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,4 @@ jobs:
           fetch-depth: 0
       - name: SonarQubeScan
         uses: SonarSource/sonarqube-scan-action@v4
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'maven'
 
       - name: Run Tests
-        run: mvn -U -B -V -ntp verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.token=${{ SONAR_TOKEN }}
+        run: mvn -U -B -V -ntp verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.token=${{ secrets.SONAR_TOKEN }}
 
       - name: Acceptance tests
         if: ${{ inputs.run_acceptance_tests }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'maven'
 
       - name: Run Tests
-        run: mvn -U -B -V -ntp verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.token=${{ secrets.SONAR_TOKEN }}
+        run: mvn -U -B -V -ntp verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.token=${{ SONAR_TOKEN }}
 
       - name: Acceptance tests
         if: ${{ inputs.run_acceptance_tests }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Checkout the repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -40,7 +42,7 @@ jobs:
           cache: 'maven'
 
       - name: Run Tests
-        run: mvn -U -B -V -ntp verify
+        run: mvn -U -B -V -ntp verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.token=${{ secrets.SONAR_TOKEN }}
 
       - name: Acceptance tests
         if: ${{ inputs.run_acceptance_tests }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,3 @@ jobs:
         uses: eclipse-pass/main/.github/actions/acceptance-test@main
         with:
           pullimages: missing
-
-  sonarqube:
-    name: SonarQube
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print description
-        run: |
-          echo "Running SonarQube Scanner"
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: SonarQubeScan
-        uses: SonarSource/sonarqube-scan-action@v4
-        secrets: inherit

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Java & Maven
         uses: actions/setup-java@v3
@@ -41,7 +43,7 @@ jobs:
       # Only execute for -SNAPSHOT versions
       - name: Publish SNAPSHOT
         if: ${{ endsWith(steps.project_version.outputs.version, '-SNAPSHOT') }}
-        run: mvn -B -ntp clean deploy
+        run: mvn -B -ntp clean deploy org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.token=${{ secrets.SONAR_TOKEN }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -43,7 +43,7 @@ jobs:
       # Only execute for -SNAPSHOT versions
       - name: Publish SNAPSHOT
         if: ${{ endsWith(steps.project_version.outputs.version, '-SNAPSHOT') }}
-        run: mvn -B -ntp clean deploy org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.token=${{ secrets.SONAR_TOKEN }}
+        run: mvn -B -ntp clean deploy org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.token=${{ SONAR_TOKEN }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -43,7 +43,7 @@ jobs:
       # Only execute for -SNAPSHOT versions
       - name: Publish SNAPSHOT
         if: ${{ endsWith(steps.project_version.outputs.version, '-SNAPSHOT') }}
-        run: mvn -B -ntp clean deploy org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.token=${{ SONAR_TOKEN }}
+        run: mvn -B -ntp clean deploy org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.token=${{ secrets.SONAR_TOKEN }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,11 @@
           </executions>
         </plugin>
 
+        <plugin>
+          <groupId>org.sonarsource.scanner.maven</groupId>
+          <artifactId>sonar-maven-plugin</artifactId>
+          <version>${sonar-maven-plugin.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -336,7 +341,6 @@
       <plugin>
         <groupId>org.sonarsource.scanner.maven</groupId>
         <artifactId>sonar-maven-plugin</artifactId>
-        <version>${sonar-maven-plugin.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
 
     <checkstyle.version>8.41.1</checkstyle.version>
     <duraspace-codestyle.version>1.1.0</duraspace-codestyle.version>
+    <sonar-maven-plugin.version>5.0.0.4389</sonar-maven-plugin.version>
+    <sonar.projectName>eclipse-pass-parent</sonar.projectName>
+    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    <sonar.organization>eclipse-pass</sonar.organization>
+    <sonar.projectKey>eclipse-pass_main</sonar.projectKey>
   </properties>
 
   <build>
@@ -326,6 +331,12 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.sonarsource.scanner.maven</groupId>
+        <artifactId>sonar-maven-plugin</artifactId>
+        <version>${sonar-maven-plugin.version}</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This PR introduces the SonarQube scanner to run on the `ci.yml` and `snapshot.yml` workflows and push the JaCoCo code coverage reports to SonarQube Cloud.

Notable changes:

- Add the SonarQube scanner to the `verify` and `deploy` maven phase.
- Add a deep checkout of the git history on the GH checkout action.

To test run the `ci.yml` or `snapshot.yml` from `pass-core` or `pass-support`. This can be tested by using another PR and referencing that workflow on the feature branch e.g. `ci.yml@feature-branch`. The SQ login secret is passed from these workflows in `pass-core` or `pass-support`. 

**Note:** the CI check fails because of `Error status returned by url [https://api.sonarcloud.io/analysis/jres?os=linux&arch=x86_64]: 401`. This is because the calling workflows from `pass-core` and `pass-support` pass the SonarQube login secret to this workflow.