### PR TITLE
Enable Main Branch Analysis on PR Merges

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -43,7 +43,7 @@ jobs:
       # Only execute for -SNAPSHOT versions
       - name: Publish SNAPSHOT
         if: ${{ endsWith(steps.project_version.outputs.version, '-SNAPSHOT') }}
-        run: mvn -B -ntp clean deploy org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.token=${{ secrets.SONAR_TOKEN }}
+        run: mvn -B -ntp clean deploy org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.branch.name=main -Dsonar.token=${{ secrets.SONAR_TOKEN }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
This PR will enable the analysis of the `main` branch when a PR is merged into `main`. SonarQube out of the box does not do this automatically and requires the argument `sonar.branch.name` when running the `mvn deploy`.

Changes: 
- Add argument `sonar.branch.name=main` to the `snapshot.yml` workflow.

To Test:
- Merge a PR into main. 

Successful merge of this PR will close #1142
