### PR TITLE
Migrate maven publishing to Central Portal

### DIFF
--- a/.github/workflows/pass-complete-release.yml
+++ b/.github/workflows/pass-complete-release.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}

--- a/.github/workflows/pass-java-release.yml
+++ b/.github/workflows/pass-java-release.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,7 @@
           <configuration>
             <publishingServerId>central</publishingServerId>
             <autoPublish>true</autoPublish>
+            <waitUntil>published</waitUntil>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,6 @@
     <url>https://github.com/eclipse-pass/main/tree/main</url>
     <tag>HEAD</tag>
   </scm>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -78,7 +72,7 @@
     <maven-javadoc-plugin.version>3.11.1</maven-javadoc-plugin.version>
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
     <tidy-maven-plugin.version>1.3.0</tidy-maven-plugin.version>
     <cyclonedx-maven-plugin.version>2.8.2</cyclonedx-maven-plugin.version>
@@ -200,16 +194,13 @@
         </plugin>
 
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${nexus-staging-maven-plugin.version}</version>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${central-publishing-maven-plugin.version}</version>
           <extensions>true</extensions>
           <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-           <!-- Set this to true and the release will automatically proceed and sync to Central Repository
-           will follow  -->
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            <publishingServerId>central</publishingServerId>
+            <autoPublish>true</autoPublish>
           </configuration>
         </plugin>
 
@@ -334,8 +325,8 @@
       </plugin>
 
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
This PR changes maven publishing from OSSRH to Central Portal.

Here are some pertinent links with the new Central Portal plugin:

Automatic publishing and waitUntil:
https://central.sonatype.org/publish/publish-portal-maven/#automatic-publishing

Snapshot publishing:
https://central.sonatype.org/publish/publish-portal-snapshots/

**Note snapshot publishing is not working, request in to EF to ensure it is enabled on Central Portal namespace.**

There are PRs opened in [pass-core](https://github.com/eclipse-pass/pass-core/pull/125) and [pass-support](https://github.com/eclipse-pass/pass-support/pull/162) as well.

