### PR TITLE
Add skipNotDeployed to cyclonedx config so SBOM generates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
     <tidy-maven-plugin.version>1.3.0</tidy-maven-plugin.version>
-    <cyclonedx-maven-plugin.version>2.8.2</cyclonedx-maven-plugin.version>
+    <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
 
     <checkstyle.version>8.41.1</checkstyle.version>
     <duraspace-codestyle.version>1.1.0</duraspace-codestyle.version>
@@ -296,6 +296,8 @@
                 <outputFormat>json</outputFormat>
                 <outputName>application.cdx</outputName>
                 <classifier>cyclonedx-sbom</classifier>
+                <!-- Needed until fix for https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/597 is released -->
+                <skipNotDeployed>false</skipNotDeployed>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
Related to Central Portal migration.  See https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/597 for reference.