### PR TITLE
Add monthly schedule for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
         description: Should acceptance tests be run?
         type: boolean
         default: true
+  schedule:
+    - cron: '5 6 15 * *'
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
So that the sonarqube token is used and doesn't get removed after 60 days of no use.