### PR TITLE
Change github workflow actions to use immutable versions

### DIFF
--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -16,13 +16,13 @@ runs:
       shell: bash
 
     - name: Checkout pass-docker
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: eclipse-pass/pass-docker
         path: pass-docker
 
     - name: Checkout pass-acceptance-testing
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: eclipse-pass/pass-acceptance-testing
         path: pass-acceptance-testing
@@ -41,7 +41,7 @@ runs:
         docker compose images
 
     - name: Use Node.js 24
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version: '24'
         cache: 'yarn'

--- a/.github/actions/node-build/action.yml
+++ b/.github/actions/node-build/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       with:
         version: 9
     - name: Builds module

--- a/.github/actions/node-version/action.yml
+++ b/.github/actions/node-version/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       with:
         version: 9
     - name: Update version and tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,12 @@ jobs:
           echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
 
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: 'temurin'

--- a/.github/workflows/deployToAWS.yml
+++ b/.github/workflows/deployToAWS.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.11'
       - name: Install Python Packages

--- a/.github/workflows/pass-complete-release.yml
+++ b/.github/workflows/pass-complete-release.yml
@@ -19,13 +19,13 @@ jobs:
       NEXT: ${{ inputs.nextversion }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: main
           fetch-depth: 0
 
       - name: Setup Java & Maven
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: 'temurin'
@@ -62,12 +62,12 @@ jobs:
           git clone https://${{ secrets.JAVA_RELEASE_PAT }}@github.com/eclipse-pass/pass-documentation.git combined/pass-documentation
 
       - name: Setup Node & pnpm
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
 
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/pass-documentation-merge.yml
+++ b/.github/workflows/pass-documentation-merge.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Development ( ${{env.DEVELOPMENT_BRANCH}} )
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.JAVA_RELEASE_PAT }}
           repository: eclipse-pass/pass-documentation

--- a/.github/workflows/pass-java-release.yml
+++ b/.github/workflows/pass-java-release.yml
@@ -23,12 +23,12 @@ jobs:
       NEXT: ${{ inputs.nextversion }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: main
 
       - name: Setup Java & Maven
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: 'temurin'
@@ -94,7 +94,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,10 @@ jobs:
       IMAGES: ${{ inputs.images }}
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Java & Maven
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: 'temurin'
@@ -101,7 +101,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Java & Maven
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: 'temurin'
@@ -50,7 +50,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
As part of security best practices update.

Pins all third-party GitHub Actions to immutable commit SHAs instead of mutable version tags. This prevents supply chain attacks where a tag (e.g. v4) could be silently moved to point to different — potentially malicious — code. The version tag is retained as a comment for readability.

Actions updated:

actions/checkout → v6.0.2
actions/setup-java → v5.2.0
actions/setup-python → v4.9.1
actions/setup-node → v5.0.0
docker/login-action → v3.7.0
pnpm/action-setup → v4.4.0