### PR TITLE
Checkout main for pass-documentation release

### DIFF
--- a/.github/workflows/pass-complete-release.yml
+++ b/.github/workflows/pass-complete-release.yml
@@ -299,6 +299,8 @@ jobs:
         if: ${{ ! env.PASS_DOCUMENTATION_TAG_EXISTS }}
         run: |
           cd combined/pass-documentation
+          git checkout main
+          git pull origin main
           git merge -m "Release $RELEASE Merge" origin/development
           git tag --force $RELEASE
           git push --atomic origin main --force $RELEASE


### PR DESCRIPTION
Fix in release all wf for pass-documentation. The default branch for pass-documentation was changed to `development`, so the release steps needs to be updated to checkout the `main` branch before merging `development` to `main`.